### PR TITLE
Feature integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,3 +38,6 @@ services:
 before_install:
   - docker pull tezos/tezos:babylonnet
   - docker run --rm -d -p 8732:8732 --name ocaml-node tezos/tezos:babylonnet tezos-node
+
+install:
+  - travis_wait cargo build --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ services:
   - docker
 
 before_install:
-  - export CURRENT_BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - bash run.sh travis
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ services:
   - docker
 
 before_install:
+  - export CURRENT_BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - bash run.sh travis
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,14 @@ services:
   - docker
 
 before_install:
-  - bash run.sh travis
+  - docker pull otisak/tezedge:latest
+  - export CURRENT_BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
+  - export GIT_CMD=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo "git checkout $CURRENT_BRANCH"; else echo "git fetch origin pull/$TRAVIS_PULL_REQUEST/head:$CURRENT_BRANCH && git checkout $CURRENT_BRANCH"; fi)
+  - docker run -d --net host -m 4g --name tezedge-node --entrypoint /bin/bash otisak/travis-tezedge:latest -c "$GIT_CMD && ./run.sh release"
+  - docker ps -a
 
 install:
-  - travis_wait 60 cargo build --verbose
+  - cargo build --verbose
 
 script:
   - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,4 +39,4 @@ before_install:
   - bash run.sh travis
 
 install:
-  - travis_wait 40 cargo build --verbose
+  - travis_wait 60 cargo build --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,15 @@ addons:
       - clang
       - libsodium-dev
       - libev4
+      - libssl-dev
 
 branches:
   only:
     - master
+
+services:
+  - docker
+
+before_install:
+  - docker pull tezos/tezos:babylonnet
+  - docker run --rm -d -p 8732:8732 --name ocaml-node tezos/tezos:babylonnet tezos-node

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,7 @@ before_install:
 
 install:
   - travis_wait 60 cargo build --verbose
+
+script:
+  cargo test --verbose
+  cargo test --verbose -- --nocapture --test-threads=1 --ignored integ_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,6 @@ services:
 
 before_install:
   - bash run.sh travis
-  - docker pull tezos/tezos:babylonnet
-  - docker run --rm -d -p 8732:8732 --name ocaml-node tezos/tezos:babylonnet tezos-node
 
 install:
   - travis_wait 40 cargo build --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ services:
   - docker
 
 before_install:
-  - sh run.sh travis
+  - bash run.sh travis
   - docker pull tezos/tezos:babylonnet
   - docker run --rm -d -p 8732:8732 --name ocaml-node tezos/tezos:babylonnet tezos-node
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ before_install:
   - docker run --rm -d -p 8732:8732 --name ocaml-node tezos/tezos:babylonnet tezos-node
 
 install:
-  - travis_wait cargo build --verbose
+  - travis_wait 40 cargo build --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ services:
   - docker
 
 before_install:
+  - sh run.sh travis
   - docker pull tezos/tezos:babylonnet
   - docker run --rm -d -p 8732:8732 --name ocaml-node tezos/tezos:babylonnet tezos-node
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,5 +42,5 @@ install:
   - travis_wait 60 cargo build --verbose
 
 script:
-  cargo test --verbose
-  cargo test --verbose -- --nocapture --test-threads=1 --ignored integ_test
+  - cargo test --verbose
+  - cargo test --verbose -- --nocapture --test-threads=1 --ignored integ_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ services:
   - docker
 
 before_install:
-  - docker pull otisak/tezedge:latest
+  - docker pull otisak/travis-tezedge:latest
   - export CURRENT_BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - export GIT_CMD=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo "git checkout $CURRENT_BRANCH"; else echo "git fetch origin pull/$TRAVIS_PULL_REQUEST/head:$CURRENT_BRANCH && git checkout $CURRENT_BRANCH"; fi)
   - docker run -d --net host -m 4g --name tezedge-node --entrypoint /bin/bash otisak/travis-tezedge:latest -c "$GIT_CMD && ./run.sh release"

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,8 @@ before_install:
   - docker pull otisak/travis-tezedge:latest
   - export CURRENT_BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - export GIT_CMD=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo "git checkout $CURRENT_BRANCH"; else echo "git fetch origin pull/$TRAVIS_PULL_REQUEST/head:$CURRENT_BRANCH && git checkout $CURRENT_BRANCH"; fi)
+  #TODO: add to entrypoint: delete data before start because database structure may change
+  - echo "starting container with '$GIT_CMD && ./run.sh release'"
   - docker run -d --net host -m 4g --name tezedge-node --entrypoint /bin/bash otisak/travis-tezedge:latest -c "$GIT_CMD && ./run.sh release"
   - docker ps -a
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "publicsuffix 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -335,7 +335,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -665,7 +665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -935,7 +935,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1011,7 +1011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1046,7 +1046,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1057,12 +1057,12 @@ dependencies = [
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1483,7 +1483,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1622,7 +1622,7 @@ dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1637,10 +1637,10 @@ version = "0.9.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2046,7 +2046,7 @@ dependencies = [
  "encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2054,14 +2054,14 @@ dependencies = [
  "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2228,7 +2228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2820,15 +2820,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2880,7 +2880,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2990,11 +2990,11 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3027,7 +3027,7 @@ dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3045,7 +3045,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3515,6 +3515,7 @@ dependencies = [
 "checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum honggfuzz 0.5.45 (registry+https://github.com/rust-lang/crates.io-index)" = "24c27b4aa3049d6d10d8e33d52c9d03ca9aec18f8a449b246f8c4a5b0c10fb34"
 "checksum http 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "d6ccf5ede3a895d8856620237b2f02972c1bbc78d2965ad7fe8838d4a0ed41f0"
+"checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum http-body 0.2.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f3aef6f3de2bd8585f5b366f3f550b5774500b4764d00cf00f903c95749eec3"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
@@ -3548,6 +3549,9 @@ dependencies = [
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 "checksum memoffset 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "75189eb85871ea5c2e2c15abbdd541185f63b408415e5051f5cac122d8c774b9"
+"checksum mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "dd1d63acd1b78403cc0c325605908475dd9b9a3acbf65ed8bcab97e27014afcf"
+"checksum mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1a0ed03949aef72dbdf3116a383d7b38b4768e6f960528cd6a6044aa9ed68599"
+"checksum miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6f3f74f726ae935c3f514300cc6773a0c9492abc5e972d42ba0c0ebb88757625"
 "checksum mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)" = "302dec22bcf6bae6dfb69c647187f4b4d0fb6f535521f7bc022430ce8e12008f"
 "checksum mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46e73a04c2fa6250b8d802134d56d554a9ec2922bf977777c805ea5def61ce40"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
@@ -3675,6 +3679,7 @@ dependencies = [
 "checksum tokio 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1f17f5d6ab0f35c1506678b28fb1798bdf74fcb737e9843c7b17b73e426eba38"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9f5d22fd1e84bd4045d28813491cb7d7caae34d45c80517c2213f09a85e8787a"
+"checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
 "checksum tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ca6df436c42b0c3330a82d855d2ef017cd793090ad550a6bc2184f4b933532ab"
 "checksum tokio-executor 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9ee9ceecf69145923834ea73f32ba40c790fd877b74a7817dd0b089f1eb9c7c8"
 "checksum tokio-fs 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bf85e16971e06e680c622e0c1b455be94b086275c5ddcd6d4a83a2bfbb83cda"
@@ -3685,6 +3690,8 @@ dependencies = [
 "checksum tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "6732fe6b53c8d11178dcb77ac6d9682af27fc6d4cb87789449152e5377377146"
 "checksum tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76"
 "checksum tokio-sync 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f1aaeb685540f7407ea0e27f1c9757d258c7c6bf4e3eb19da6fc59b747239d2"
+"checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
+"checksum tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "2bd2c6a3885302581f4401c82af70d792bb9df1700e7437b0aeb4ada94d5388c"
 "checksum tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1739638e364e558128461fc1ad84d997702c8e31c2e6b18fb99842268199e827"
 "checksum tokio-timer 0.3.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b97c1587fe71018eb245a4a9daa13a5a3b681bbc1f7fdadfe24720e141472c13"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
@@ -3694,6 +3701,7 @@ dependencies = [
 "checksum tracing-attributes 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a4263b12c3d3c403274493eb805966093b53214124796552d674ca1dd5d27c2b"
 "checksum tracing-core 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "bc913647c520c959b6d21e35ed8fa6984971deca9f0a2fcb8c51207e0c56af1d"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
+"checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum typename 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c255dd1af8cf5cfb95f062266201778080d215e86294dba14c47bf3137c55419"
 "checksum typename_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c68acf2f6e8a32e2bad47e73ee177558583fb9dbb264a5c0569c7f9f80f79b0a"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -300,6 +301,46 @@ dependencies = [
 [[package]]
 name = "constant_time_eq"
 version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "cookie"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "publicsuffix 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -518,9 +559,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "enum-iterator"
@@ -561,6 +615,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "failure"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,8 +659,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz_oxide 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -643,6 +729,15 @@ dependencies = [
 name = "futures-core-preview"
 version = "0.3.0-alpha.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "futures-cpupool"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "futures-executor-preview"
@@ -833,6 +928,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "h2"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "h2"
 version = "0.2.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -894,6 +1006,17 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "http-body"
 version = "0.2.0-alpha.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -912,6 +1035,35 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hyper"
+version = "0.12.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -945,9 +1097,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "idna"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "idna"
@@ -1115,6 +1289,7 @@ dependencies = [
  "logging 0.1.0",
  "monitoring 0.1.0",
  "networking 0.1.0",
+ "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "riker 0.3.2 (git+https://github.com/simplestaking/riker.git?branch=slog-support)",
  "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rpc 0.1.0",
@@ -1208,6 +1383,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "mio"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,6 +1475,23 @@ dependencies = [
  "tezos_messages 0.1.0",
  "tokio 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
+ "schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1400,6 +1614,36 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "openssl"
+version = "0.10.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vcpkg 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "os_type"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1449,6 +1693,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "peeking_take_while"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "percent-encoding"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1525,6 +1774,18 @@ dependencies = [
  "tezos_interop_callback 0.0.1-pre20",
  "tezos_messages 0.1.0",
  "tezos_wrapper 0.1.0",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1774,6 +2035,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.9.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime_guess 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "riker"
 version = "0.3.2"
 source = "git+https://github.com/simplestaking/riker.git?branch=slog-support#84a58eaf22da0c7c5d0546d0a702767e177a5b15"
@@ -1914,9 +2208,37 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "schannel"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "security-framework"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "semver"
@@ -1982,6 +2304,17 @@ version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2482,6 +2815,24 @@ dependencies = [
 
 [[package]]
 name = "tokio"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-threadpool 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio"
 version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2502,6 +2853,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-buf"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio-codec"
 version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,6 +2872,15 @@ dependencies = [
  "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-current-thread"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2551,6 +2921,16 @@ dependencies = [
  "tokio-executor 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-sync 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-io"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2602,6 +2982,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-reactor"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-sync"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio-sync"
 version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2610,6 +3017,35 @@ dependencies = [
  "futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-sink-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-util-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-tcp"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-threadpool"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2694,6 +3130,14 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "try_from"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "typename"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,6 +3163,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "ucd-util"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -2755,6 +3207,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "url"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "url"
@@ -2804,6 +3266,11 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2814,6 +3281,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "want"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2883,6 +3360,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winreg"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2964,6 +3449,10 @@ dependencies = [
 "checksum commitlog 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fa0861eaf1d6f05437649378e26c1763d29124d300212471b69136f0de20d566"
 "checksum config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "f9107d78ed62b3fa5a86e7d18e647abed48cfd8f8fab6c72f4cdb982d196f7e6"
 "checksum constant_time_eq 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "995a44c877f9212528ccc74b21a232f66ad69001e40ede5bcee2ac9ef2657120"
+"checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
+"checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
+"checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
+"checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum crc32c 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77ba37ef26c12988c1cee882d522d65e1d5d2ad8c3864665b88ee92767ed84c5"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "69323bff1fb41c635347b8ead484a5ca6c3f11914d784170b158d8449ab07f8e"
@@ -2985,16 +3474,22 @@ dependencies = [
 "checksum dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 "checksum dirs-sys 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "afa0b23de8fd801745c471deffa6e12d248f962c9fd4b4c33787b055599bde7b"
 "checksum dns-lookup 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13988670860b076248c74e1b54444efc4f1dec70c8bb25da4b7c0024396b72bf"
+"checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
+"checksum encoding_rs 0.8.20 (registry+https://github.com/rust-lang/crates.io-index)" = "87240518927716f79692c2ed85bfe6e98196d18c6401ec75355760233a7e12e9"
 "checksum enum-iterator 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de783877b4c72e6ec1c1b4b32eb4a6446e7b8021c8b1898e419f973fd09c4291"
 "checksum enum-iterator-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb3f06af72cbd86aa47dc2efeac193199e1ad3d2c4b4c8ee39175a6d643eb5e6"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum erased-serde 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3beee4bc16478a1b26f2e80ad819a52d24745e292f521a63c16eea5f74b7eb60"
+"checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f8273f13c977665c5db7eb2b99ae520952fe5ac831ae4cd09d80c4c7042b5ed9"
 "checksum failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bc225b78e0391e4b8683440bf2e63c2deeeb2ce5189eab46e2b68c6d3725d08"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum filetime 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"
+"checksum flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6bd6d6f4752952feb71363cffc9ebac9411b75b87c6ab6058c40c8900cf43c0f"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+"checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+"checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5f2a4a2034423744d2cc7ca2068453168dcdb82c438419e639a26bd87839c674"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -3002,6 +3497,7 @@ dependencies = [
 "checksum futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)" = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 "checksum futures-channel-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "d5e5f4df964fa9c1c2f8bddeb5c3611631cacd93baf810fc8bb2fb4b495c263a"
 "checksum futures-core-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "b35b6263fb1ef523c3056565fa67b1d16f0a8604ff12b11b08c25f28a734c60a"
+"checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum futures-executor-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "75236e88bd9fe88e5e8bfcd175b665d0528fe03ca4c5207fabc028c8f9d93e98"
 "checksum futures-io-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "f4914ae450db1921a56c91bde97a27846287d062087d4a652efc09bb3a01ebda"
 "checksum futures-preview 0.3.0-alpha.19 (registry+https://github.com/rust-lang/crates.io-index)" = "3b1dce2a0267ada5c6ff75a8ba864b4e679a9e2aa44262af7a3b5516d530d76e"
@@ -3012,6 +3508,7 @@ dependencies = [
 "checksum getrandom 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "e7db7ca94ed4cd01190ceee0d8a8052f08a247aa1b469a7f68c6a3b71afcf407"
 "checksum getset 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "5bb3f5b7d8d70c9bd23cf29b2b38094661418fb0ea79f1b0cc2019a11d6f5429"
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+"checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum h2 0.2.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0f107db1419ef8271686187b1a5d47c6431af4a7f4d98b495e7b7fc249bb0a78"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
 "checksum hermit-abi 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "307c3c9f937f38e3534b1d6447ecf090cafcc9744e4a6360e8b037b2cf5af120"
@@ -3021,8 +3518,11 @@ dependencies = [
 "checksum http-body 0.2.0-alpha.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1f3aef6f3de2bd8585f5b366f3f550b5774500b4764d00cf00f903c95749eec3"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+"checksum hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)" = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
 "checksum hyper 0.13.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2d05aa523087ac0b9d8b93dd80d5d482a697308ed3b0dca7b0667511a7fa7cdc"
+"checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 "checksum ident_case 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+"checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
@@ -3052,6 +3552,7 @@ dependencies = [
 "checksum mio-extras 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "46e73a04c2fa6250b8d802134d56d554a9ec2922bf977777c805ea5def61ce40"
 "checksum mio-uds 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "966257a94e196b11bb43aca423754d87429960a768de9414f3691d6957abf125"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nix 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c722bee1037d430d0f8e687bbdbf222f27cc6e4e68d5caf630857bb2b6dbdce"
 "checksum nix 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
@@ -3063,12 +3564,16 @@ dependencies = [
 "checksum num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76dac5ed2a876980778b8b85f75a71b6cbf0db0b1232ee12f826bccb00d09d72"
 "checksum ocaml 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b497481786e5fa6606783d684f5eb0671721fac38efae1930e8a58f4335b9d2a"
 "checksum opaque-debug 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+"checksum openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)" = "3a3cc5799d98e1088141b8e01ff760112bbd9f19d850c124500566ca6901a585"
+"checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+"checksum openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)" = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
 "checksum os_type 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7edc011af0ae98b7f88cf7e4a83b70a54a75d2b8cb013d6efd02e5956207e9eb"
 "checksum page_size 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f89ef58b3d32420dbd1a43d2f38ae92f6239ef12bb556ab09ca55445f5a67242"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
 "checksum path-tree 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f5ea01163c5c21c901e0dfd4194cae527d0260a6223f8ec158b9b35e59a22af1"
 "checksum peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 "checksum pin-project 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "94b90146c7216e4cb534069fb91366de4ea0ea353105ee45ed297e2d1619e469"
 "checksum pin-project-internal 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "44ca92f893f0656d3cba8158dd0f2b99b94de256a4a54e870bd6922fcc6c8355"
@@ -3077,6 +3582,7 @@ dependencies = [
 "checksum ppv-lite86 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
+"checksum publicsuffix 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
@@ -3104,6 +3610,7 @@ dependencies = [
 "checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
+"checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
 "checksum riker 0.3.2 (git+https://github.com/simplestaking/riker.git?branch=slog-support)" = "<none>"
 "checksum riker 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "28db5ac9d5e68e3fc4d71a7a1da905f6051d1dd1d44e0c0db6867f5b6af8c68b"
 "checksum riker-macros 0.1.0 (git+https://github.com/simplestaking/riker.git?branch=slog-support)" = "<none>"
@@ -3116,7 +3623,10 @@ dependencies = [
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
+"checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+"checksum security-framework 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8ef2429d7cefe5fd28bd1d2ed41c944547d4ff84776f5935b456da44593a16df"
+"checksum security-framework-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e31493fc37615debb8c5090a7aeb4a9730bc61e77ab10b9af59f1a202284f895"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
@@ -3125,6 +3635,7 @@ dependencies = [
 "checksum serde_derive 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)" = "a8c6faef9a2e64b0064f48570289b4bf8823b7581f1d6157c1b52152306651d0"
 "checksum serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)" = "48c575e0cc52bdd09b47f330f646cf59afc586e9c4e3ccd6fc1f625b8ea1dad7"
 "checksum serde_test 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
+"checksum serde_urlencoded 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "642dd69105886af2efd227f75a520ec9b44a820d65bc133a9131f7d229fd165a"
 "checksum serial_test 0.3.0 (git+https://github.com/palfrey/serial_test.git)" = "<none>"
 "checksum serial_test_derive 0.3.0 (git+https://github.com/palfrey/serial_test.git)" = "<none>"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
@@ -3160,14 +3671,19 @@ dependencies = [
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum timeout_io 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d89ed29f92507ee770ef31f747ec1ad5ba7d8989a9f3489783da7d19a155c60"
+"checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "1f17f5d6ab0f35c1506678b28fb1798bdf74fcb737e9843c7b17b73e426eba38"
+"checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9f5d22fd1e84bd4045d28813491cb7d7caae34d45c80517c2213f09a85e8787a"
 "checksum tokio-executor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ca6df436c42b0c3330a82d855d2ef017cd793090ad550a6bc2184f4b933532ab"
 "checksum tokio-executor 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9ee9ceecf69145923834ea73f32ba40c790fd877b74a7817dd0b089f1eb9c7c8"
 "checksum tokio-fs 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bf85e16971e06e680c622e0c1b455be94b086275c5ddcd6d4a83a2bfbb83cda"
+"checksum tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "5090db468dad16e1a7a54c8c67280c5e4b544f3d3e018f0b913b400261f85926"
 "checksum tokio-io 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "112784d5543df30660b04a72ca423bfbd90e8bb32f94dcf610f15401218b22c5"
 "checksum tokio-macros 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "86b616374bcdadd95974e1f0dfca07dc913f1163c53840c0d664aca35114964e"
 "checksum tokio-net 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a441682cd32f3559383112c4a7f372f5c9fa1950c5cf8c8dd05274a2ce8c2654"
+"checksum tokio-reactor 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "6732fe6b53c8d11178dcb77ac6d9682af27fc6d4cb87789449152e5377377146"
+"checksum tokio-sync 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "d06554cce1ae4a50f42fba8023918afa931413aded705b560e29600ccf7c6d76"
 "checksum tokio-sync 0.2.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4f1aaeb685540f7407ea0e27f1c9757d258c7c6bf4e3eb19da6fc59b747239d2"
 "checksum tokio-timer 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1739638e364e558128461fc1ad84d997702c8e31c2e6b18fb99842268199e827"
 "checksum tokio-timer 0.3.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "b97c1587fe71018eb245a4a9daa13a5a3b681bbc1f7fdadfe24720e141472c13"
@@ -3182,12 +3698,14 @@ dependencies = [
 "checksum typename_derive 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c68acf2f6e8a32e2bad47e73ee177558583fb9dbb264a5c0569c7f9f80f79b0a"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum ucd-util 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa9b3b49edd3468c0e6565d85783f51af95212b6fa3986a5500954f00b460874"
+"checksum unicase 2.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "b561e267b2326bb4cebfc0ef9e68355c7abe6c6f522aeac2f5bf95d56c59bdcf"
 "checksum unicode-segmentation 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
 "checksum unicode-width 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7007dbd421b92cc6e28410fe7362e2e0a2503394908f417b68ec8d1c364c4e20"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+"checksum url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dd4e7c0d531266369519a4aa4f399d748bd37043b00bde1e4ff1f60a120b355a"
 "checksum url 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75b414f6c464c879d7f9babf951f23bc3743fb7313c081b2e6ca719067ea9d61"
 "checksum utf8-ranges 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 "checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
@@ -3195,8 +3713,10 @@ dependencies = [
 "checksum vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3fc439f2794e98976c88a2a2dafce96b930fe8010b0a256b3c2199a773933168"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+"checksum version_check 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wait-timeout 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+"checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 "checksum want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum which 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b57acb10231b9493c8472b20cb57317d0679a49e0bdbee44b3b803a6473af164"
@@ -3207,6 +3727,7 @@ dependencies = [
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 "checksum wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
+"checksum winreg 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 "checksum ws 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a2c47b5798ccc774ffb93ff536aec7c4275d722fd9c740c83cdd1af1f2d94"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xattr 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,15 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "assert-json-diff"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1279,6 +1288,7 @@ dependencies = [
 name = "light-node"
 version = "0.1.0"
 dependencies = [
+ "assert-json-diff 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto 0.1.0",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3421,6 +3431,7 @@ dependencies = [
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+"checksum assert-json-diff 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9881d306dee755eccf052d652b774a6b2861e86b4772f555262130e58e4f81d2"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"

--- a/docker/travis/Dockerfile
+++ b/docker/travis/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage 1
+FROM simplestakingcom/tezos-opam-builder:debian10
+# Checkout and compile tezedge source code
+ARG tezedge_git="https://github.com/simplestaking/tezedge.git"
+ARG rust_toolchain="nightly-2019-11-25"
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${rust_toolchain} -y
+ENV PATH=/home/appuser/.cargo/bin:$PATH
+ENV RUST_BACKTRACE=1
+ENV SODIUM_USE_PKG_CONFIG=1
+ENV OCAML_BUILD_CHAIN=remote
+RUN cd /home/appuser && git clone ${tezedge_git} && cd tezedge && git checkout master
+WORKDIR /home/appuser/tezedge
+ENTRYPOINT ["./run.sh", "release"]
+CMD []

--- a/docker/travis/Dockerfile
+++ b/docker/travis/Dockerfile
@@ -3,13 +3,13 @@ FROM simplestakingcom/tezos-opam-builder:debian10
 # Checkout and compile tezedge source code
 ARG tezedge_git="https://github.com/simplestaking/tezedge.git"
 ARG rust_toolchain="nightly-2019-11-25"
-ARG to_checkout="master"
+ARG current_branch="master"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${rust_toolchain} -y
 ENV PATH=/home/appuser/.cargo/bin:$PATH
 ENV RUST_BACKTRACE=1
 ENV SODIUM_USE_PKG_CONFIG=1
 ENV OCAML_BUILD_CHAIN=remote
-RUN cd /home/appuser && git clone ${tezedge_git} && cd tezedge && git checkout ${to_checkout}
+RUN cd /home/appuser && git clone ${tezedge_git} && cd tezedge && git checkout ${current_branch}
 WORKDIR /home/appuser/tezedge
 ENTRYPOINT ["./run.sh", "release"]
 CMD []

--- a/docker/travis/Dockerfile
+++ b/docker/travis/Dockerfile
@@ -3,12 +3,13 @@ FROM simplestakingcom/tezos-opam-builder:debian10
 # Checkout and compile tezedge source code
 ARG tezedge_git="https://github.com/simplestaking/tezedge.git"
 ARG rust_toolchain="nightly-2019-11-25"
+ARG travis_branch="master"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${rust_toolchain} -y
 ENV PATH=/home/appuser/.cargo/bin:$PATH
 ENV RUST_BACKTRACE=1
 ENV SODIUM_USE_PKG_CONFIG=1
 ENV OCAML_BUILD_CHAIN=remote
-RUN cd /home/appuser && git clone ${tezedge_git} && cd tezedge && git checkout $TRAVIS_BRANCH
+RUN cd /home/appuser && git clone ${tezedge_git} && cd tezedge && git checkout ${travis_branch}
 WORKDIR /home/appuser/tezedge
 ENTRYPOINT ["./run.sh", "release"]
 CMD []

--- a/docker/travis/Dockerfile
+++ b/docker/travis/Dockerfile
@@ -9,6 +9,7 @@ ENV PATH=/home/appuser/.cargo/bin:$PATH
 ENV RUST_BACKTRACE=1
 ENV SODIUM_USE_PKG_CONFIG=1
 ENV OCAML_BUILD_CHAIN=remote
+RUN echo ${current_branch}
 RUN cd /home/appuser && git clone ${tezedge_git} && cd tezedge && git checkout ${current_branch}
 WORKDIR /home/appuser/tezedge
 ENTRYPOINT ["./run.sh", "release"]

--- a/docker/travis/Dockerfile
+++ b/docker/travis/Dockerfile
@@ -3,13 +3,13 @@ FROM simplestakingcom/tezos-opam-builder:debian10
 # Checkout and compile tezedge source code
 ARG tezedge_git="https://github.com/simplestaking/tezedge.git"
 ARG rust_toolchain="nightly-2019-11-25"
-ARG travis_branch="master"
+ARG to_checkout="master"
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain ${rust_toolchain} -y
 ENV PATH=/home/appuser/.cargo/bin:$PATH
 ENV RUST_BACKTRACE=1
 ENV SODIUM_USE_PKG_CONFIG=1
 ENV OCAML_BUILD_CHAIN=remote
-RUN cd /home/appuser && git clone ${tezedge_git} && cd tezedge && git checkout ${travis_branch}
+RUN cd /home/appuser && git clone ${tezedge_git} && cd tezedge && git checkout ${to_checkout}
 WORKDIR /home/appuser/tezedge
 ENTRYPOINT ["./run.sh", "release"]
 CMD []

--- a/docker/travis/Dockerfile
+++ b/docker/travis/Dockerfile
@@ -10,7 +10,7 @@ ENV RUST_BACKTRACE=1
 ENV SODIUM_USE_PKG_CONFIG=1
 ENV OCAML_BUILD_CHAIN=remote
 RUN echo ${current_branch}
-RUN cd /home/appuser && git clone ${tezedge_git} && cd tezedge && git checkout ${current_branch}
+RUN cd /home/appuser && git clone ${tezedge_git} && cd tezedge
 WORKDIR /home/appuser/tezedge
 ENTRYPOINT ["./run.sh", "release"]
 CMD []

--- a/docker/travis/Dockerfile
+++ b/docker/travis/Dockerfile
@@ -8,7 +8,7 @@ ENV PATH=/home/appuser/.cargo/bin:$PATH
 ENV RUST_BACKTRACE=1
 ENV SODIUM_USE_PKG_CONFIG=1
 ENV OCAML_BUILD_CHAIN=remote
-RUN cd /home/appuser && git clone ${tezedge_git} && cd tezedge && git checkout master
+RUN cd /home/appuser && git clone ${tezedge_git} && cd tezedge && git checkout $TRAVIS_BRANCH
 WORKDIR /home/appuser/tezedge
 ENTRYPOINT ["./run.sh", "release"]
 CMD []

--- a/light_node/Cargo.toml
+++ b/light_node/Cargo.toml
@@ -35,3 +35,4 @@ rpc = { path = "../rpc" }
 
 [dev-dependencies]
 reqwest = "0.9.22"
+assert-json-diff = "1.0.1"

--- a/light_node/Cargo.toml
+++ b/light_node/Cargo.toml
@@ -32,3 +32,6 @@ storage = { path = "../storage" }
 shell = { path = "../shell" }
 monitoring = { path = "../monitoring" }
 rpc = { path = "../rpc" }
+
+[dev-dependencies]
+reqwest = "0.9.22"

--- a/light_node/etc/tezedge/integ_tests.json
+++ b/light_node/etc/tezedge/integ_tests.json
@@ -1,1 +1,1 @@
-{"rust_node_url":"http://127.0.0.1:18732","ocaml_node_url":"https://alphanet.simplestaking.com:3000"}
+{"rust_node_url":"http://127.0.0.1:18732","ocaml_node_url":"https://alphanet.simplestaking.com:3000","block_id":"BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK","cycle":"0"}

--- a/light_node/etc/tezedge/integ_tests.json
+++ b/light_node/etc/tezedge/integ_tests.json
@@ -1,0 +1,1 @@
+{"rust_node_url":"http://127.0.0.1:18732","ocaml_node_url":"https://alphanet.simplestaking.com:3000"}

--- a/light_node/tests/common.rs
+++ b/light_node/tests/common.rs
@@ -6,18 +6,27 @@ use std::mem::discriminant;
 use failure::Error;
 
 
-pub fn call_rpc_json(uri: String) -> Result<Value, Error> {
-    let json = reqwest::get(&uri)?.json()?;
-    println!("resp for uri {} is {:?}", uri, json);
-    Ok(json)
-}
+// pub fn call_rpc_json(uri: String, ssl: bool) -> Result<Value, Error> {
+//     if ssl {
+//         call_rpc_json_ssl(uri)
+//     } else {
+//         call_rpc_json_nossl(uri)
+//     }
+// }
 
-pub fn call_rpc_ssl_json(uri: String) -> Result<Value, Error> {
+// this is not supporting ssl
+// pub fn call_rpc_json_nossl(uri: String) -> Result<Value, Error> {
+//     let json = reqwest::get(&uri)?.json()?;
+//     println!("resp for uri {} is {:?}", uri, json);
+//     Ok(json)
+// }
+
+pub fn call_rpc_json(uri: String) -> Result<Value, Error> {
     let mut res = reqwest::Client::builder()
         .danger_accept_invalid_certs(true).build()?
         .get(&uri).send()?;
     let json: Value = res.json()?;
-    println!("resp for uri {} is {:?}", uri, json);
+    //println!("resp for uri {} is {:?}", uri, json);
     Ok(json)
 }
 
@@ -28,7 +37,7 @@ fn unpack_value_option(opt: Option<&Value>) -> &Value {
     }
 }
 
-// compare json structures of a flat Object
+// compare json structures of a single layer Object
 pub fn json_structure_match( json1: &Value, json2: &Value) -> bool {
     match (json1, json2) {
         (Value::Object(j1), Value::Object(j2)) => 

--- a/light_node/tests/common.rs
+++ b/light_node/tests/common.rs
@@ -7,20 +7,21 @@ use std::mem::discriminant;
 use failure::Error;
 
 
-pub fn compare_json_structure_of_rpc(uri1: String, uri2: String) -> Result<bool, Error> {
-    let res1 = call_rpc(uri1)?;
-    let res2 = call_rpc(uri2)?;
-
-    let json1: HashMap<String, Value> = serde_json::from_str(&res1)?;
-    let json2: HashMap<String, Value> = serde_json::from_str(&res2)?;
-
-    //compare structure of json
-    Ok(json_structure_match(&json1, &json2))
+pub fn call_rpc_json(uri: String) -> Result<HashMap<String, Value>, Error> {
+    let json = reqwest::get(&uri)?.json()?;
+    println!("resp for uri {} is {:?}", uri, json);
+    Ok(json)
 }
 
-fn call_rpc(request_url: String) -> Result<String, reqwest::Error> {
-    let response_string = reqwest::get(&request_url)?.text()?;
-    Ok(response_string)
+pub fn call_rpc_ssl_json(uri: String) -> Result<HashMap<String, Value>, Error> {
+    let mut res = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()?
+        .get(&uri)
+        .send()?;
+    let json: HashMap<String, Value> = res.json()?;
+    println!("resp for uri {} is {:?}", uri, json);
+    Ok(json)
 }
 
 fn unpack_value_option(opt: Option<&Value>) -> &Value {

--- a/light_node/tests/common.rs
+++ b/light_node/tests/common.rs
@@ -2,24 +2,21 @@ extern crate reqwest; //sudo apt-get install libssl-dev
 extern crate serde_json;
 
 use serde_json::Value;
-use std::collections::HashMap;
 use std::mem::discriminant;
 use failure::Error;
 
 
-pub fn call_rpc_json(uri: String) -> Result<HashMap<String, Value>, Error> {
+pub fn call_rpc_json(uri: String) -> Result<Value, Error> {
     let json = reqwest::get(&uri)?.json()?;
     println!("resp for uri {} is {:?}", uri, json);
     Ok(json)
 }
 
-pub fn call_rpc_ssl_json(uri: String) -> Result<HashMap<String, Value>, Error> {
+pub fn call_rpc_ssl_json(uri: String) -> Result<Value, Error> {
     let mut res = reqwest::Client::builder()
-        .danger_accept_invalid_certs(true)
-        .build()?
-        .get(&uri)
-        .send()?;
-    let json: HashMap<String, Value> = res.json()?;
+        .danger_accept_invalid_certs(true).build()?
+        .get(&uri).send()?;
+    let json: Value = res.json()?;
     println!("resp for uri {} is {:?}", uri, json);
     Ok(json)
 }
@@ -31,7 +28,12 @@ fn unpack_value_option(opt: Option<&Value>) -> &Value {
     }
 }
 
-pub fn json_structure_match( map1: &HashMap<String, Value>, map2: &HashMap<String, Value>) -> bool {
-    map1.len() == map2.len() && map1.keys().all(|k| map2.contains_key(k) 
-        && discriminant(unpack_value_option(map1.get(k))) == discriminant(unpack_value_option(map2.get(k))))
+// compare json structures of a flat Object
+pub fn json_structure_match( json1: &Value, json2: &Value) -> bool {
+    match (json1, json2) {
+        (Value::Object(j1), Value::Object(j2)) => 
+            j1.len() == j2.len() && j1.keys().all(|k| j2.contains_key(k) 
+                && discriminant(unpack_value_option(j1.get(k))) == discriminant(unpack_value_option(j2.get(k)))),
+        _ => false
+    }
 }

--- a/light_node/tests/common.rs
+++ b/light_node/tests/common.rs
@@ -1,0 +1,36 @@
+extern crate reqwest; //sudo apt-get install libssl-dev
+extern crate serde_json;
+
+use serde_json::Value;
+use std::collections::HashMap;
+use std::mem::discriminant;
+use failure::Error;
+
+
+pub fn compare_json_structure_of_rpc(uri1: String, uri2: String) -> Result<bool, Error> {
+    let res1 = call_rpc(uri1)?;
+    let res2 = call_rpc(uri2)?;
+
+    let json1: HashMap<String, Value> = serde_json::from_str(&res1)?;
+    let json2: HashMap<String, Value> = serde_json::from_str(&res2)?;
+
+    //compare structure of json
+    Ok(json_structure_match(&json1, &json2))
+}
+
+fn call_rpc(request_url: String) -> Result<String, reqwest::Error> {
+    let response_string = reqwest::get(&request_url)?.text()?;
+    Ok(response_string)
+}
+
+fn unpack_value_option(opt: Option<&Value>) -> &Value {
+    match opt {
+        Some(v) => v,
+        None => &Value::Null
+    }
+}
+
+pub fn json_structure_match( map1: &HashMap<String, Value>, map2: &HashMap<String, Value>) -> bool {
+    map1.len() == map2.len() && map1.keys().all(|k| map2.contains_key(k) 
+        && discriminant(unpack_value_option(map1.get(k))) == discriminant(unpack_value_option(map2.get(k))))
+}

--- a/light_node/tests/integration_test.rs
+++ b/light_node/tests/integration_test.rs
@@ -19,7 +19,7 @@ fn integ_test1_wait_connect_rust_node() {
     let mut timeout_counter = 0;
     let step: u32 = 30; //s
     let sleep_duration = Duration::from_secs(step as u64);
-    let timeout: u32 = 600; // s
+    let timeout: u32 = 900; // s
     loop {
         match reqwest::get("http://127.0.0.1:18732/stats/memory") { //maybe we should implement server status RPC call
             Ok(resp) => { 
@@ -61,7 +61,7 @@ fn integ_test2_wait_bootstrapp_rust_node() {
     let mut timeout_counter = 0;
     let step: u32 = 30; //s
     let sleep_duration = Duration::from_secs(step as u64);
-    let timeout: u32 = 600; // s
+    let timeout: u32 = 900; // s
     loop {
         // bootstrap to exact block, try to get block level 269
         let resp = reqwest::get("http://127.0.0.1:18732/chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK").unwrap();
@@ -90,7 +90,7 @@ fn integ_test2_wait_bootstrapp_rust_node() {
 fn integ_test3_rpc_stats_memory() {
 
     let json_rust = common::call_rpc_json("http://127.0.0.1:18732/stats/memory".to_string()).unwrap();
-    let json_ocaml = common::call_rpc_json("https://zeronet.simplestaking.com:3000/stats/memory".to_string()).unwrap();
+    let json_ocaml = common::call_rpc_json("https://alphanet.simplestaking.com:3000/stats/memory".to_string()).unwrap();
 
     assert!(common::json_structure_match(&json_rust, &json_ocaml))
 }
@@ -100,8 +100,7 @@ fn integ_test3_rpc_stats_memory() {
 fn integ_test4_rpc_chains_main_blocks_hash() {
 
     let json_rust = common::call_rpc_json("http://127.0.0.1:18732/chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK".to_string()).unwrap();
-    //let json_ocaml = common::call_rpc_json("https://zeronet.simplestaking.com:3000/chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK".to_string()).unwrap();
-    let json_ocaml = common::call_rpc_json("http://babylon.tezedge.com:18732/chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK".to_string()).unwrap();
+    let json_ocaml = common::call_rpc_json("https://alphanet.simplestaking.com:3000/chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK".to_string()).unwrap();
 
     assert_json_eq!(json_rust, json_ocaml);
 }

--- a/light_node/tests/integration_test.rs
+++ b/light_node/tests/integration_test.rs
@@ -1,19 +1,25 @@
+#[macro_use]
+extern crate assert_json_diff;
 extern crate reqwest;
 use std::thread::sleep;
 use std::time::Duration;
 
 mod common;
 
+//use serde_json::Value;
+
+// integration tests are running sequentialy and need to have configured connection to running ocaml and rust tezos nodes:
+// cargo test --verbose -- --nocapture --test-threads=1 --ignored integ_test
 
 #[test]
 #[ignore]
-fn integ_test_wait_connect_rust_node() {
+fn integ_test1_wait_connect_rust_node() {
 
     let mut connected = false;
     let mut timeout_counter = 0;
     let step: u32 = 30; //s
     let sleep_duration = Duration::from_secs(step as u64);
-    let timeout: u32 = 900; // s
+    let timeout: u32 = 600; // s
     loop {
         match reqwest::get("http://127.0.0.1:18732/stats/memory") { //maybe we should implement server status RPC call
             Ok(resp) => { 
@@ -22,20 +28,22 @@ fn integ_test_wait_connect_rust_node() {
                     break
                 } else {
                     if timeout_counter < timeout {
-                        timeout_counter += step;
                         println!("Waiting for RPC server {}s", timeout_counter);
+                        timeout_counter += step;
                         sleep(sleep_duration)
                     } else {
+                        println!("Error: timeout for RPC server {}s", timeout_counter);
                         break
                     }
                 }
             },
             Err(_e) => {
                 if timeout_counter < timeout {
-                    timeout_counter += step;
                     println!("Waiting for RPC server {}s", timeout_counter);
+                    timeout_counter += step;
                     sleep(sleep_duration)
                 } else {
+                    println!("Error: timeout for RPC server {}s", timeout_counter);
                     break
                 }
             }
@@ -45,13 +53,55 @@ fn integ_test_wait_connect_rust_node() {
     assert!(connected)
 }
 
+#[test]
+#[ignore]
+fn integ_test2_wait_bootstrapp_rust_node() {
+
+    let mut bootstrapped = false;
+    let mut timeout_counter = 0;
+    let step: u32 = 30; //s
+    let sleep_duration = Duration::from_secs(step as u64);
+    let timeout: u32 = 600; // s
+    loop {
+        // bootstrap to exact block, try to get block level 269
+        let resp = reqwest::get("http://127.0.0.1:18732/chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK").unwrap();
+        if resp.status().is_success() {
+            // let resp_object: Value = resp.json().unwrap();
+            // println!("block head {:?}", resp_object.get("hash").unwrap());
+            bootstrapped = true;
+            break
+        } else {
+            if timeout_counter < timeout {
+                println!("Waiting for bootstrapp server {}s", timeout_counter);
+                timeout_counter += step;
+                sleep(sleep_duration)
+            } else {
+                println!("Bootstrapping server timed out {}s", timeout_counter);
+                break
+            }
+        }
+    };
+
+    assert!(bootstrapped)
+}
 
 #[test]
 #[ignore]
-fn integ_test_rpc_stats_memory() {
+fn integ_test3_rpc_stats_memory() {
 
     let json_rust = common::call_rpc_json("http://127.0.0.1:18732/stats/memory".to_string()).unwrap();
-    let json_ocaml = common::call_rpc_ssl_json("https://zeronet.simplestaking.com:3000/stats/memory".to_string()).unwrap();
+    let json_ocaml = common::call_rpc_json("https://zeronet.simplestaking.com:3000/stats/memory".to_string()).unwrap();
 
     assert!(common::json_structure_match(&json_rust, &json_ocaml))
+}
+
+#[test]
+#[ignore]
+fn integ_test4_rpc_chains_main_blocks_hash() {
+
+    let json_rust = common::call_rpc_json("http://127.0.0.1:18732/chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK".to_string()).unwrap();
+    //let json_ocaml = common::call_rpc_json("https://zeronet.simplestaking.com:3000/chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK".to_string()).unwrap();
+    let json_ocaml = common::call_rpc_json("http://babylon.tezedge.com:18732/chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK".to_string()).unwrap();
+
+    assert_json_eq!(json_rust, json_ocaml);
 }

--- a/light_node/tests/integration_test.rs
+++ b/light_node/tests/integration_test.rs
@@ -5,7 +5,6 @@ mod common;
 // 2 nodes(rust,ocaml) must run and be bootstraped before these tests can be executed
 
 #[test]
-#[ignore]
 fn integ_test_rpc_stats_memory() {
 
     let uri1 = "http://127.0.0.1:18732/stats/memory".to_string(); // local rust node

--- a/light_node/tests/integration_test.rs
+++ b/light_node/tests/integration_test.rs
@@ -1,0 +1,14 @@
+mod common;
+
+// 2 nodes(rust,ocaml) must run and be bootstraped before these tests can be executed
+
+#[test]
+#[ignore]
+fn integ_rpc_stats_memory() {
+
+    let uri1 = "http://127.0.0.1:18732/stats/memory".to_string(); // local rust node
+    let uri2 = "http://127.0.0.1:8732/stats/memory".to_string(); // local ocaml node
+
+    assert!(common::compare_json_structure_of_rpc(uri1, uri2).unwrap())
+}
+

--- a/light_node/tests/integration_test.rs
+++ b/light_node/tests/integration_test.rs
@@ -4,18 +4,9 @@ mod common;
 
 // 2 nodes(rust,ocaml) must run and be bootstraped before these tests can be executed
 
-#[test]
-#[ignore]
-fn integ_test_rpc_stats_memory() {
-
-    let uri1 = "http://127.0.0.1:18732/stats/memory".to_string(); // local rust node
-    let uri2 = "http://127.0.0.1:8732/stats/memory".to_string(); // local ocaml node
-
-    assert!(common::compare_json_structure_of_rpc(uri1, uri2).unwrap())
-}
 
 #[test]
-fn integ_test_check_rust_node() {
+fn integ_test_connect_rust_node() {
 
     let resp = reqwest::get("http://127.0.0.1:18732/stats/memory").unwrap();
     assert!(resp.status().is_success())
@@ -23,10 +14,13 @@ fn integ_test_check_rust_node() {
 }
 
 #[test]
-fn integ_test_check_ocaml_node_out() {
+fn integ_test_rpc_stats_memory() {
 
-    let resp = reqwest::get("https://zeronet.simplestaking.com:3000/stats/memory").unwrap();
-    assert!(resp.status().is_success())
+    let json_rust = common::call_rpc_json("http://127.0.0.1:8732/stats/memory".to_string()).unwrap();
+    let json_ocaml = common::call_rpc_ssl_json("https://zeronet.simplestaking.com:3000/stats/memory".to_string()).unwrap();
 
+    assert!(common::json_structure_match(&json_rust, &json_ocaml))
 }
+
+
 

--- a/light_node/tests/integration_test.rs
+++ b/light_node/tests/integration_test.rs
@@ -21,3 +21,11 @@ fn integ_test_check_ocaml_node() {
 
 }
 
+#[test]
+fn integ_test_check_ocaml_node_out() {
+
+    let resp = reqwest::get("https://zeronet.simplestaking.com:3000/stats/memory").unwrap();
+    assert!(resp.status().is_success())
+
+}
+

--- a/light_node/tests/integration_test.rs
+++ b/light_node/tests/integration_test.rs
@@ -15,13 +15,19 @@ mod common;
 #[ignore]
 fn integ_test1_wait_connect_rust_node() {
 
+    let cfg = common::get_config().unwrap();
+    let rust_node_url = cfg["rust_node_url"].as_str().unwrap();
+
+    //maybe we should implement server status RPC call
+    let url = format!("{}/{}", rust_node_url, "stats/memory");
+
     let mut connected = false;
     let mut timeout_counter = 0;
     let step: u32 = 30; //s
     let sleep_duration = Duration::from_secs(step as u64);
     let timeout: u32 = 900; // s
     loop {
-        match reqwest::get("http://127.0.0.1:18732/stats/memory") { //maybe we should implement server status RPC call
+        match common::call_rpc(&url) {
             Ok(resp) => { 
                 if resp.status().is_success() {
                     connected = true;
@@ -57,6 +63,12 @@ fn integ_test1_wait_connect_rust_node() {
 #[ignore]
 fn integ_test2_wait_bootstrapp_rust_node() {
 
+    let cfg = common::get_config().unwrap();
+    let rust_node_url = cfg["rust_node_url"].as_str().unwrap();
+
+    //maybe we should implement server status RPC call
+    let url = format!("{}/{}", rust_node_url, "chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK");
+
     let mut bootstrapped = false;
     let mut timeout_counter = 0;
     let step: u32 = 30; //s
@@ -64,7 +76,7 @@ fn integ_test2_wait_bootstrapp_rust_node() {
     let timeout: u32 = 900; // s
     loop {
         // bootstrap to exact block, try to get block level 269
-        let resp = reqwest::get("http://127.0.0.1:18732/chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK").unwrap();
+        let resp = common::call_rpc(&url).unwrap();
         if resp.status().is_success() {
             // let resp_object: Value = resp.json().unwrap();
             // println!("block head {:?}", resp_object.get("hash").unwrap());
@@ -89,8 +101,15 @@ fn integ_test2_wait_bootstrapp_rust_node() {
 #[ignore]
 fn integ_test3_rpc_stats_memory() {
 
-    let json_rust = common::call_rpc_json("http://127.0.0.1:18732/stats/memory".to_string()).unwrap();
-    let json_ocaml = common::call_rpc_json("https://alphanet.simplestaking.com:3000/stats/memory".to_string()).unwrap();
+    let cfg = common::get_config().unwrap();
+    let ocaml_node_url = cfg["ocaml_node_url"].as_str().unwrap();
+    let rust_node_url = cfg["rust_node_url"].as_str().unwrap();
+
+    let url_ocaml = format!("{}/{}", ocaml_node_url, "stats/memory");
+    let url_rust = format!("{}/{}", rust_node_url, "stats/memory");
+
+    let json_rust = common::call_rpc_json(&url_ocaml).unwrap();
+    let json_ocaml = common::call_rpc_json(&url_rust).unwrap();
 
     assert!(common::json_structure_match(&json_rust, &json_ocaml))
 }
@@ -99,8 +118,15 @@ fn integ_test3_rpc_stats_memory() {
 #[ignore]
 fn integ_test4_rpc_chains_main_blocks_hash() {
 
-    let json_rust = common::call_rpc_json("http://127.0.0.1:18732/chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK".to_string()).unwrap();
-    let json_ocaml = common::call_rpc_json("https://alphanet.simplestaking.com:3000/chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK".to_string()).unwrap();
+    let cfg = common::get_config().unwrap();
+    let ocaml_node_url = cfg["ocaml_node_url"].as_str().unwrap();
+    let rust_node_url = cfg["rust_node_url"].as_str().unwrap();
+
+    let url_ocaml = format!("{}/{}", ocaml_node_url, "chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK");
+    let url_rust = format!("{}/{}", rust_node_url, "chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK");
+
+    let json_rust = common::call_rpc_json(&url_ocaml).unwrap();
+    let json_ocaml = common::call_rpc_json(&url_rust).unwrap();
 
     assert_json_eq!(json_rust, json_ocaml);
 }

--- a/light_node/tests/integration_test.rs
+++ b/light_node/tests/integration_test.rs
@@ -65,9 +65,10 @@ fn integ_test2_wait_bootstrapp_rust_node() {
 
     let cfg = common::get_config().unwrap();
     let rust_node_url = cfg["rust_node_url"].as_str().unwrap();
+    let block_id = cfg["block_id"].as_str().unwrap();
 
     //maybe we should implement server status RPC call
-    let url = format!("{}/{}", rust_node_url, "chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK");
+    let url = format!("{}/{}/{}", rust_node_url, "chains/main/blocks",block_id);
 
     let mut bootstrapped = false;
     let mut timeout_counter = 0;
@@ -75,7 +76,7 @@ fn integ_test2_wait_bootstrapp_rust_node() {
     let sleep_duration = Duration::from_secs(step as u64);
     let timeout: u32 = 900; // s
     loop {
-        // bootstrap to exact block, try to get block level 269
+        // bootstrap to exact block
         let resp = common::call_rpc(&url).unwrap();
         if resp.status().is_success() {
             // let resp_object: Value = resp.json().unwrap();
@@ -116,14 +117,88 @@ fn integ_test3_rpc_stats_memory() {
 
 #[test]
 #[ignore]
-fn integ_test4_rpc_chains_main_blocks_hash() {
+fn integ_test4_rpc_chains_main_blocks_id() {
 
     let cfg = common::get_config().unwrap();
     let ocaml_node_url = cfg["ocaml_node_url"].as_str().unwrap();
-    let rust_node_url = cfg["rust_node_url"].as_str().unwrap();
+    let rust_node_url = cfg["ocaml_node_url"].as_str().unwrap(); //TODO: replace for rust_node_url after command available
+    let block_id = cfg["block_id"].as_str().unwrap();
 
-    let url_ocaml = format!("{}/{}", ocaml_node_url, "chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK");
-    let url_rust = format!("{}/{}", rust_node_url, "chains/main/blocks/BLTrP8PxKtE7ajTPGPkeP5iKPs6zZvTMhv7BCVLainLsEeTXLEK");
+    let url_ocaml = format!("{}/{}/{}", ocaml_node_url, "chains/main/blocks", block_id);
+    let url_rust = format!("{}/{}/{}", rust_node_url, "chains/main/blocks", block_id);
+
+    let json_rust = common::call_rpc_json(&url_ocaml).unwrap();
+    let json_ocaml = common::call_rpc_json(&url_rust).unwrap();
+
+    assert_json_eq!(json_rust, json_ocaml);
+}
+
+#[test]
+#[ignore]
+fn integ_test5_rpc_chains_main_blocks_id_helpers_baking() {
+
+    let cfg = common::get_config().unwrap();
+    let ocaml_node_url = cfg["ocaml_node_url"].as_str().unwrap();
+    let rust_node_url = cfg["ocaml_node_url"].as_str().unwrap(); //TODO: replace for rust_node_url after command available
+    let block_id = cfg["block_id"].as_str().unwrap();
+
+    let url_ocaml = format!("{}/{}/{}/{}", ocaml_node_url, "chains/main/blocks", block_id, "helpers/baking_rights");
+    let url_rust = format!("{}/{}/{}/{}", rust_node_url, "chains/main/blocks", block_id, "helpers/baking_rights");
+
+    let json_rust = common::call_rpc_json(&url_ocaml).unwrap();
+    let json_ocaml = common::call_rpc_json(&url_rust).unwrap();
+
+    assert_json_eq!(json_rust, json_ocaml);
+}
+
+#[test]
+#[ignore]
+fn integ_test6_rpc_chains_main_blocks_id_helpers_endorsing() {
+
+    let cfg = common::get_config().unwrap();
+    let ocaml_node_url = cfg["ocaml_node_url"].as_str().unwrap();
+    let rust_node_url = cfg["ocaml_node_url"].as_str().unwrap(); //TODO: replace for rust_node_url after command available
+    let block_id = cfg["block_id"].as_str().unwrap();
+
+    let url_ocaml = format!("{}/{}/{}/{}", ocaml_node_url, "chains/main/blocks", block_id, "helpers/endorsing_rights");
+    let url_rust = format!("{}/{}/{}/{}", rust_node_url, "chains/main/blocks", block_id, "helpers/endorsing_rights");
+
+    let json_rust = common::call_rpc_json(&url_ocaml).unwrap();
+    let json_ocaml = common::call_rpc_json(&url_rust).unwrap();
+
+    assert_json_eq!(json_rust, json_ocaml);
+}
+
+#[test]
+#[ignore]
+fn integ_test7_rpc_chains_main_blocks_id_context_cycle() {
+
+    let cfg = common::get_config().unwrap();
+    let ocaml_node_url = cfg["ocaml_node_url"].as_str().unwrap();
+    let rust_node_url = cfg["ocaml_node_url"].as_str().unwrap(); //TODO: replace for rust_node_url after command available
+    let block_id = cfg["block_id"].as_str().unwrap();
+    let cycle = cfg["cycle"].as_str().unwrap();
+
+    let url_ocaml = format!("{}/{}/{}/{}/{}", ocaml_node_url, "chains/main/blocks", block_id, "context/raw/json/cycle", cycle);
+    let url_rust = format!("{}/{}/{}/{}/{}", rust_node_url, "chains/main/blocks", block_id, "context/raw/json/cycle", cycle);
+
+    let json_rust = common::call_rpc_json(&url_ocaml).unwrap();
+    let json_ocaml = common::call_rpc_json(&url_rust).unwrap();
+
+    assert_json_eq!(json_rust, json_ocaml);
+}
+
+#[test]
+#[ignore]
+fn integ_test8_rpc_chains_main_blocks_id_context_constants() {
+
+    let cfg = common::get_config().unwrap();
+    let ocaml_node_url = cfg["ocaml_node_url"].as_str().unwrap();
+    let rust_node_url = cfg["ocaml_node_url"].as_str().unwrap(); //TODO: replace for rust_node_url after command available
+    let block_id = cfg["block_id"].as_str().unwrap();
+
+    let url_ocaml = format!("{}/{}/{}/{}", ocaml_node_url, "chains/main/blocks", block_id, "context/constants");
+    let url_rust = format!("{}/{}/{}/{}", rust_node_url, "chains/main/blocks", block_id, "context/constants");
 
     let json_rust = common::call_rpc_json(&url_ocaml).unwrap();
     let json_ocaml = common::call_rpc_json(&url_rust).unwrap();

--- a/light_node/tests/integration_test.rs
+++ b/light_node/tests/integration_test.rs
@@ -16,7 +16,7 @@ fn integ_test_connect_rust_node() {
 #[test]
 fn integ_test_rpc_stats_memory() {
 
-    let json_rust = common::call_rpc_json("http://127.0.0.1:8732/stats/memory".to_string()).unwrap();
+    let json_rust = common::call_rpc_json("http://127.0.0.1:18732/stats/memory".to_string()).unwrap();
     let json_ocaml = common::call_rpc_ssl_json("https://zeronet.simplestaking.com:3000/stats/memory".to_string()).unwrap();
 
     assert!(common::json_structure_match(&json_rust, &json_ocaml))

--- a/light_node/tests/integration_test.rs
+++ b/light_node/tests/integration_test.rs
@@ -1,14 +1,24 @@
+extern crate reqwest;
+
 mod common;
 
 // 2 nodes(rust,ocaml) must run and be bootstraped before these tests can be executed
 
 #[test]
 #[ignore]
-fn integ_rpc_stats_memory() {
+fn integ_test_rpc_stats_memory() {
 
     let uri1 = "http://127.0.0.1:18732/stats/memory".to_string(); // local rust node
     let uri2 = "http://127.0.0.1:8732/stats/memory".to_string(); // local ocaml node
 
     assert!(common::compare_json_structure_of_rpc(uri1, uri2).unwrap())
+}
+
+#[test]
+fn integ_test_check_ocaml_node() {
+
+    let resp = reqwest::get("http://127.0.0.1:8732/stats/memory").unwrap();
+    assert!(resp.status().is_success())
+
 }
 

--- a/light_node/tests/integration_test.rs
+++ b/light_node/tests/integration_test.rs
@@ -5,6 +5,7 @@ mod common;
 // 2 nodes(rust,ocaml) must run and be bootstraped before these tests can be executed
 
 #[test]
+#[ignore]
 fn integ_test_rpc_stats_memory() {
 
     let uri1 = "http://127.0.0.1:18732/stats/memory".to_string(); // local rust node
@@ -14,9 +15,9 @@ fn integ_test_rpc_stats_memory() {
 }
 
 #[test]
-fn integ_test_check_ocaml_node() {
+fn integ_test_check_rust_node() {
 
-    let resp = reqwest::get("http://127.0.0.1:8732/stats/memory").unwrap();
+    let resp = reqwest::get("http://127.0.0.1:18732/stats/memory").unwrap();
     assert!(resp.status().is_success())
 
 }

--- a/run.sh
+++ b/run.sh
@@ -205,7 +205,7 @@ case $1 in
   travis)
     printf "\033[1;37mRunning Tezedge node in docker\e[0m\n"
     run_travis_docker "$@"
-    travis_check_rpc_running
+    #travis_check_rpc_running
     ;;
 
   -h|--help)

--- a/run.sh
+++ b/run.sh
@@ -167,8 +167,7 @@ run_travis_docker() {
   shift # shift past <MODE>
 
   # build docker
-  cd ./docker/travis || exit 1
-  docker build -t tezedge-run --build-arg to_checkout=$TRAVIS_COMMIT .
+  docker build -t tezedge-run -f ./docker/travis/Dockerfile --build-arg to_checkout=$TRAVIS_COMMIT .
   # run docker on background with port forwarding for RPC
   #docker run --rm -d -m 4g -p 18732:18732 --name rust-node tezedge-run "$@"
   docker run --rm -d --net host -m 4g --name rust-node tezedge-run "$@"

--- a/run.sh
+++ b/run.sh
@@ -167,10 +167,10 @@ run_travis_docker() {
   shift # shift past <MODE>
 
   # build docker
-  docker build -t tezedge-run -f ./docker/travis/Dockerfile --build-arg current_branch=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} .
+  docker build -t travis-tezedge -f ./docker/travis/Dockerfile --build-arg current_branch=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} .
   # run docker on background with port forwarding for RPC
   #docker run --rm -d -m 4g -p 18732:18732 --name rust-node tezedge-run "$@"
-  docker run -d --net host -m 4g --name rust-node tezedge-run "$@"
+  docker run -d --net host -m 4g --name tezedge-node travis-tezedge "$@"
 }
 
 travis_check_rpc_running() {

--- a/run.sh
+++ b/run.sh
@@ -170,7 +170,7 @@ run_travis_docker() {
   docker build -t tezedge-run -f ./docker/travis/Dockerfile --build-arg current_branch=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} .
   # run docker on background with port forwarding for RPC
   #docker run --rm -d -m 4g -p 18732:18732 --name rust-node tezedge-run "$@"
-  docker run --rm -d --net host -m 4g --name rust-node tezedge-run "$@"
+  docker run -d --net host -m 4g --name rust-node tezedge-run "$@"
 }
 
 travis_check_rpc_running() {

--- a/run.sh
+++ b/run.sh
@@ -171,7 +171,7 @@ run_travis_docker() {
   docker build -t tezedge-run --build-arg travis_branch=${TRAVIS_BRANCH} .
   # run docker on background with port forwarding for RPC
   #docker run --rm -d -m 4g -p 18732:18732 --name rust-node tezedge-run "$@"
-  docker run --rm -d --net host -m 2g --name rust-node tezedge-run "$@"
+  docker run --rm -d --net host -m 4g --name rust-node tezedge-run "$@"
 }
 
 travis_check_rpc_running() {

--- a/run.sh
+++ b/run.sh
@@ -168,7 +168,7 @@ run_travis_docker() {
 
   # build docker
   cd ./docker/travis || exit 1
-  docker build -t tezedge-run .
+  docker build -t tezedge-run --build-arg travis_branch=${TRAVIS_BRANCH} .
   # run docker on background with port forwarding for RPC
   #docker run --rm -d -m 4g -p 18732:18732 --name rust-node tezedge-run "$@"
   docker run --rm -d --net host -m 2g --name rust-node tezedge-run "$@"

--- a/run.sh
+++ b/run.sh
@@ -168,7 +168,7 @@ run_travis_docker() {
 
   # build docker
   cd ./docker/travis || exit 1
-  docker build -t tezedge-run --build-arg travis_branch=${TRAVIS_BRANCH} .
+  docker build -t tezedge-run --build-arg to_checkout=$TRAVIS_COMMIT .
   # run docker on background with port forwarding for RPC
   #docker run --rm -d -m 4g -p 18732:18732 --name rust-node tezedge-run "$@"
   docker run --rm -d --net host -m 4g --name rust-node tezedge-run "$@"

--- a/run.sh
+++ b/run.sh
@@ -167,7 +167,7 @@ run_travis_docker() {
   shift # shift past <MODE>
 
   # build docker
-  docker build -t tezedge-run -f ./docker/travis/Dockerfile --build-arg current_branch=$CURRENT_BRANCH .
+  docker build -t tezedge-run -f ./docker/travis/Dockerfile --build-arg current_branch=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} .
   # run docker on background with port forwarding for RPC
   #docker run --rm -d -m 4g -p 18732:18732 --name rust-node tezedge-run "$@"
   docker run --rm -d --net host -m 4g --name rust-node tezedge-run "$@"

--- a/run.sh
+++ b/run.sh
@@ -171,7 +171,7 @@ run_travis_docker() {
   docker build -t tezedge-run .
   # run docker on background with port forwarding for RPC
   #docker run --rm -d -m 4g -p 18732:18732 --name rust-node tezedge-run "$@"
-  docker run --rm -d --net host -m 4g --name rust-node tezedge-run "$@"
+  docker run --rm -d --net host -m 2g --name rust-node tezedge-run "$@"
 }
 
 travis_check_rpc_running() {

--- a/run.sh
+++ b/run.sh
@@ -167,7 +167,7 @@ run_travis_docker() {
   shift # shift past <MODE>
 
   # build docker
-  docker build -t tezedge-run -f ./docker/travis/Dockerfile --build-arg to_checkout=$TRAVIS_COMMIT .
+  docker build -t tezedge-run -f ./docker/travis/Dockerfile --build-arg current_branch=$CURRENT_BRANCH .
   # run docker on background with port forwarding for RPC
   #docker run --rm -d -m 4g -p 18732:18732 --name rust-node tezedge-run "$@"
   docker run --rm -d --net host -m 4g --name rust-node tezedge-run "$@"


### PR DESCRIPTION
- implement integration test for one RPC call (stats/memory) to have proof of work

- target is to run ocaml and rust node in Travis before tests are executed:
1. stage wait till nodes are running and respond to RPC calls
2. stage wait till nodes are bootstrapped (best to start them with most actual DB)

- lets have tests run i 2 stages:
1. - unit tests (cargo test)
2. - integration tests (cargo test -- --ignored integ_test)

