### PR TITLE
drone CI/CD integration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,54 @@
+kind: pipeline
+name: default
+
+steps:
+- name: build-tezedge
+  image: adonagy/tezedge-ci-builder:latest
+  user: root
+  environment:
+    RUST_BACKTRACE: 1
+    SODIUM_USE_PKG_CONFIG: 1
+    OCAML_BUILD_CHAIN: remote
+    LD_LIBRARY_PATH: ./tezos/interop/lib_tezos/artifacts
+  commands:
+    - cargo clean && cargo build --release
+
+- name: tezedge-node-run
+  image: adonagy/tezedge-ci-builder:latest
+  user: root
+  detach: true
+  environment:
+    RUST_BACKTRACE: 1
+    SODIUM_USE_PKG_CONFIG: 1
+    OCAML_BUILD_CHAIN: remote
+    LD_LIBRARY_PATH: ./tezos/interop/lib_tezos/artifacts
+  commands: 
+    - mkdir /tmp/tezedge
+    - cargo run --release --bin light-node -- --config-file ./light_node/etc/tezedge/tezedge.config --protocol-runner "./target/release/protocol-runner" --p2p-port 19733 --identity-file /drone/src/docker/identities/identity_tezedge.json --ffi-calls-gc-treshold=2000 --peers 176.191.110.22:9732,23.96.48.25:19732,164.68.124.104:19732
+
+- name: ocaml-node-run
+  image: tezos/tezos:babylonnet
+  detach: true
+  commands:
+    - mkdir /home/tezos/data
+    - cp /drone/src/docker/identities/identity_ocaml.json /home/tezos/data/identity.json
+    - tezos-node run --rpc-addr 0.0.0.0 --net-addr 0.0.0.0:9734 --data-dir /home/tezos/data --history-mode archive 
+
+- name: bootstrapping
+  image: adonagy/tezos-node-bootstrap:latest
+
+- name: test
+  image: adonagy/tezedge-ci-builder:latest
+  pull: if-not-exists
+  user: root
+  environment:
+    RUST_BACKTRACE: 1
+    SODIUM_USE_PKG_CONFIG: 1
+    OCAML_BUILD_CHAIN: remote
+    LD_LIBRARY_PATH: ./tezos/interop/lib_tezos/artifacts
+  commands:
+    - cargo test --verbose --release -- --nocapture --ignored integration_test_dev
+
+trigger:
+  branch:
+    - master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,15 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "assert-json-diff"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.44 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1931,6 +1940,8 @@ dependencies = [
 name = "rpc"
 version = "0.1.0"
 dependencies = [
+ "assert-json-diff 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crypto 0.1.0",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2561,7 +2572,17 @@ dependencies = [
  "pin-project-lite 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook-registry 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-macros 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2838,6 +2859,7 @@ dependencies = [
 "checksum arc-swap 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b8a9123b8027467bce0099fe556c628a53c8d83df0507084c31e9ba2e39aff"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+"checksum assert-json-diff 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9881d306dee755eccf052d652b774a6b2861e86b4772f555262130e58e4f81d2"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
@@ -3071,6 +3093,7 @@ dependencies = [
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum timeout_io 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2d89ed29f92507ee770ef31f747ec1ad5ba7d8989a9f3489783da7d19a155c60"
 "checksum tokio 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "bcced6bb623d4bff3739c176c415f13c418f426395c169c9c3cd9a492c715b16"
+"checksum tokio-macros 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5795a71419535c6dcecc9b6ca95bdd3c2d6142f7e8343d7beb9923f129aa87e"
 "checksum tokio-util 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
 "checksum toml 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
 "checksum tower-service 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"

--- a/docker/identities/identity_ocaml.json
+++ b/docker/identities/identity_ocaml.json
@@ -1,0 +1,6 @@
+{ "peer_id": "idrRoknJh9zwEePNswF3MPGFzmKaVp",
+  "public_key":
+    "5fd7ba1d15650abc9a510c37a8bee566b708fe6577f0d832b903e8f13d71c94a",
+  "secret_key":
+    "213d61d6e41b443bec6bf0d00f17f59dfb4bdca409c9c03887cc5196be12502e",
+  "proof_of_work_stamp": "4b1354dcfc087e52c8fb510317b9464c297b8a55b79bfc95" }

--- a/docker/identities/identity_tezedge.json
+++ b/docker/identities/identity_tezedge.json
@@ -1,0 +1,6 @@
+{ "peer_id": "idsyBpzU3VspRyD3GEDWkgUBRqQNti",
+  "public_key":
+    "8072b92ac74f031808b56c916f291b08201a6957c127f51bae66c1a754ad4209",
+  "secret_key":
+    "46d55abdea246d1d3a3cd9ee746e5d17341e5bbf6765bbcd500ebf08fff46dba",
+  "proof_of_work_stamp": "788a80b4326f0e04eef11ae8ce67c69e2db372ff57d3b23b" }

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 slog = { version = "2.5", features = ["nested-values"] }
 slog_derive = "0.1.1"
-tokio = "0.2"
+tokio = { version = "0.2", features = ["macros"] }
 # local dependencies
 crypto = { path = "../crypto" }
 networking = { path = "../networking" }
@@ -30,3 +30,7 @@ tezos_api = { path = "../tezos/api" }
 tezos_context = { path = "../tezos/context" }
 tezos_encoding = { path = "../tezos/encoding" }
 tezos_messages = { path = "../tezos/messages" }
+
+[dev-dependencies]
+assert-json-diff = "1.0.0"
+bytes = "0.5"

--- a/rpc/tests/integration_tests.rs
+++ b/rpc/tests/integration_tests.rs
@@ -1,0 +1,93 @@
+// Copyright (c) SimpleStaking and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use assert_json_diff::assert_json_eq;
+use bytes::buf::BufExt;
+use hyper::Client;
+
+#[derive(Debug)]
+pub enum NodeType {
+    Tezedge,
+    Ocaml,
+}
+
+#[ignore]
+#[tokio::test]
+async fn integration_test_full() {
+    // to execute test run 'cargo test --verbose -- --nocapture --ignored integration_test_full'
+    // start full test from level 125717
+    integration_tests_rpc("BM61Z4zsa8Vu3zF3CYcMa4ZHUfttmJ2eVUavLmC5Lfbnv2dq4Gw").await
+}
+
+#[ignore]
+#[tokio::test]
+async fn integration_test_dev() {
+    // to execute test run 'cargo test --verbose -- --nocapture --ignored integration_test_dev'
+    // start development tests from 1000th block
+    integration_tests_rpc("BM9xFVaVv6mi7ckPbTgxEe7TStcfFmteJCpafUZcn75qi2wAHrC").await
+}
+
+
+async fn integration_tests_rpc(start_block: &str) {
+    let mut prev_block = start_block.to_string();
+
+    while prev_block != "" {
+        println!("{}", &format!("{}/{}", "chains/main/blocks", &prev_block));
+        let block_json = get_rpc_as_json(NodeType::Ocaml, &format!("{}/{}", "chains/main/blocks", &prev_block)).await
+            .expect("Failed to get block from ocaml");
+        let predecessor = block_json["header"]["predecessor"]
+            .to_string()
+            .replace("\"", "");
+        // Do not check genesys block
+        if prev_block == "BLockGenesisGenesisGenesisGenesisGenesisd1f7bcGMoXy" {
+            println!("Genesis block reached and checked, breaking loop...");
+            break;
+        }
+
+        // -------------------------- Integration tests for RPC --------------------------
+        // ---------------------- Please keep one function per test ----------------------
+
+        test_rpc_compare_json(&format!("{}/{}", "chains/main/blocks", &prev_block)).await;
+        //test_rpc_compare_json(&format!("{}/{}/{}", "chains/main/blocks", &prev_block, "helpers/baking_rights"));
+        //test_rpc_compare_json(&format!("{}/{}/{}", "chains/main/blocks", &prev_block, "helpers/endorsing_rights"));
+        //test_rpc_compare_json(&format!("{}/{}/{}", "chains/main/blocks", &prev_block, "context/constants"));
+        // not sure about cycles probably need to be more specific test to loop over all possible cycles
+        //test_rpc_compare_json(&format!("{}/{}/{}", "chains/main/blocks", &prev_block, "context/raw/json/cycle/0"));
+
+        // --------------------------------- End of tests --------------------------------
+
+        prev_block = predecessor;
+    }
+}
+
+async fn test_rpc_compare_json(rpc_path: &str) {
+    // print the asserted path, to know which one errored in case of an error, use --nocapture
+    println!("Checking: {}", rpc_path);
+    let ocaml_json = get_rpc_as_json(NodeType::Ocaml, rpc_path).await.unwrap();
+    let tezedge_json = get_rpc_as_json(NodeType::Tezedge, rpc_path).await.unwrap();
+    assert_json_eq!(tezedge_json, ocaml_json);
+}
+
+async fn get_rpc_as_json(node: NodeType, rpc_path: &str) -> Result<serde_json::value::Value, serde_json::error::Error> {
+    let url = match node {
+        NodeType::Ocaml => format!(
+            "http://ocaml-node-run:8732/{}",
+            //"http://127.0.0.1:8732/{}", //switch for local testing
+            rpc_path
+        ), // reference Ocaml node
+        NodeType::Tezedge => format!(
+            "http://tezedge-node-run:18732/{}",
+            //"http://ocaml-node-run:8732/{}", // POW that tests are OK
+            //"http://127.0.0.1:18732/{}", //swith for local testing
+            rpc_path
+        ), // Tezedge node
+    }.parse().expect("Invalid URL");
+
+    let client = Client::new();
+    let body = match client.get(url).await {
+        Ok(res) => hyper::body::aggregate(res.into_body()).await.expect("Failed to read response body"),
+        Err(e) => panic!("Request for getting block failed: {}", e),
+    };
+
+    serde_json::from_reader(&mut body.reader())
+}


### PR DESCRIPTION
This PR adds drone CI integration tests to the checks.

To activate the CI:

1. login to https://cloud.drone.io/ as simplestaking
2. activate the repo

The pipeline consists of the following steps:

1. Drone automatically clones the repo and mounts it as a volume into all the pipeline steps (each step is a new container launched)
2. Drone builds the tezedge node using the following [image](https://github.com/adonagy/tezedge-ci-builder/blob/master/Dockerfile)
3. Next, drone launches 2 detached containers, one with the built tezedge node running, one with an ocaml babylonnet node
4. Drone waits for the nodes to be bootstrapped to a specific block (block level 1k for now) using a simple dockerised rust program found [here](https://github.com/adonagy/tezos-node-bootstrap), that blocks the pipeline until the nodes apply the required blocks
5. When the nodes are bootstrapped drone runs the integration tests

A working example of the pipeline: https://cloud.drone.io/adonagy/tezedge/138/1/1

A sample of what the passed test should look like (comparing between the same output from the ocaml node): https://cloud.drone.io/adonagy/tezedge/134/1/6

This is a working example for the pipeline, further polishing is most likely required. (E.g. moving the Dockerfiles to this repo, etc...)

