### PR TITLE
Get block by level, static genesis data

### DIFF
--- a/rpc/src/server/service.rs
+++ b/rpc/src/server/service.rs
@@ -864,7 +864,7 @@ mod fns {
                 block = block_storage.get_by_block_level_with_json_data(val)?.map(|(header, json_data)| map_header_and_json_to_full_block_info(header, json_data, &state));
             }
             Err(_e) => {
-                let block_hash = block_id_to_block_hash(block_id, persistent_storage)?;
+                let block_hash = get_block_hash_by_block_id(block_id, persistent_storage, state)?;
                 block = block_storage.get_with_json_data(&block_hash)?.map(|(header, json_data)| map_header_and_json_to_full_block_info(header, json_data, &state));
             }
         }

--- a/rpc/src/server/service.rs
+++ b/rpc/src/server/service.rs
@@ -855,9 +855,19 @@ mod fns {
     /// Get information about block
     pub(crate) fn get_full_block(block_id: &str, persistent_storage: &PersistentStorage, state: &RpcCollectedStateRef) -> Result<Option<FullBlockInfo>, failure::Error> {
         let block_storage = BlockStorage::new(persistent_storage);
-        let block_hash = get_block_hash_by_block_id(block_id, persistent_storage, state)?;
-        let block = block_storage.get_with_json_data(&block_hash)?.map(|(header, json_data)| map_header_and_json_to_full_block_info(header, json_data, state));
+        let block;
 
+        // hotfix
+        // TODO: rework block_id to accept types String and integer for block levels
+        match block_id.parse() {
+            Ok(val) => {
+                block = block_storage.get_by_block_level_with_json_data(val)?.map(|(header, json_data)| map_header_and_json_to_full_block_info(header, json_data, &state));
+            }
+            Err(_e) => {
+                let block_hash = block_id_to_block_hash(block_id, persistent_storage)?;
+                block = block_storage.get_with_json_data(&block_hash)?.map(|(header, json_data)| map_header_and_json_to_full_block_info(header, json_data, &state));
+            }
+        }
         Ok(block)
     }
 

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -133,6 +133,17 @@ pub fn initialize_storage_with_genesis_block(genesis_hash: &BlockHash, genesis: 
     if block_storage.get(&genesis_with_hash.hash)?.is_none() {
         info!(log, "Initializing storage with genesis block");
         block_storage.put_block_header(&genesis_with_hash)?;
+        // TODO: include the data for the other chains as well (mainet, zeronet, etc.)
+        // just for babylonnet for now
+        let genesis_meta_string = "{\"protocol\":\"PrihK96nBAFSxVL1GLJTVhu9YnzkMFiBeuJRPA8NwuZVZCE1L6i\",\"next_protocol\":\"PtBMwNZT94N7gXKw4i273CKcSaBrrBnqnt3RATExNKr9KNX2USV\",\"test_chain_status\":{\"status\":\"not_running\"},\"max_operations_ttl\":0,\"max_operation_data_length\":0,\"max_block_header_length\":115,\"max_operation_list_length\":[]}".to_string();
+        let genesis_op_string = "{\"operations\":[]}".to_string();
+        let genesis_prot_string = "".to_string();
+        let block_json_data = BlockJsonDataBuilder::default()
+            .block_header_proto_json(genesis_prot_string)
+            .block_header_proto_metadata_json(genesis_meta_string)
+            .operations_proto_metadata_json(genesis_op_string)
+            .build().unwrap();
+        block_storage.put_block_json_data(&genesis_with_hash.hash, block_json_data)?;
         let mut block_meta_storage = BlockMetaStorage::new(persistent_storage);
         block_meta_storage.put(&genesis_with_hash.hash, &block_meta_storage::Meta::genesis_meta(&genesis_with_hash.hash, genesis_chain_id))?;
         let mut operations_meta_storage = OperationsMetaStorage::new(persistent_storage);


### PR DESCRIPTION
- Quick fix of getting the block when the URL paramater block_id is the level of the block. 
- Add more static genesis data for babylonnet

Do not merge into master. Will need proper rework