### PR TITLE
TE-89 endorsing rights refactor

### DIFF
--- a/rpc/src/encoding/conversions.rs
+++ b/rpc/src/encoding/conversions.rs
@@ -1,0 +1,117 @@
+use failure::bail;
+
+use crypto::hash::{BlockHash, ChainId, HashType};
+use crypto::blake2b;
+use storage::{BlockStorage, BlockStorageReader};
+use storage::context_storage::ContractAddress;
+use storage::persistent::PersistentStorage;
+
+/// Get block has bytes from block hash or block level
+#[inline]
+pub fn block_id_to_block_hash(block_id: &str, persistent_storage: &PersistentStorage) -> Result<BlockHash, failure::Error> {
+    
+    let block_storage = BlockStorage::new(persistent_storage);
+    let block_hash = match block_id.parse() {
+        Ok(value) =>  match block_storage.get_by_block_level(value)? {
+            Some(current_head) => current_head.hash,
+            None => vec![]
+        },
+        Err(_e) => HashType::BlockHash.string_to_bytes(block_id)?   
+    };
+
+    Ok(block_hash)
+}
+
+#[inline]
+pub fn contract_id_to_address(contract_id: &str) -> Result<ContractAddress, failure::Error> {
+    let contract_address = {
+        if contract_id.len() == 44 {
+            hex::decode(contract_id)?
+        } else if contract_id.len() > 3 {
+            let mut contract_address = Vec::with_capacity(22);
+            match &contract_id[0..3] {
+                "tz1" => {
+                    contract_address.extend(&[0, 0]);
+                    contract_address.extend(&HashType::ContractTz1Hash.string_to_bytes(contract_id)?);
+                }
+                "tz2" => {
+                    contract_address.extend(&[0, 1]);
+                    contract_address.extend(&HashType::ContractTz2Hash.string_to_bytes(contract_id)?);
+                }
+                "tz3" => {
+                    contract_address.extend(&[0, 2]);
+                    contract_address.extend(&HashType::ContractTz3Hash.string_to_bytes(contract_id)?);
+                }
+                "KT1" => {
+                    contract_address.push(1);
+                    contract_address.extend(&HashType::ContractKt1Hash.string_to_bytes(contract_id)?);
+                    contract_address.push(0);
+                }
+                _ => bail!("Invalid contract id")
+            }
+            contract_address
+        } else {
+            bail!("Invalid contract id");
+        }
+    };
+
+    Ok(contract_address)
+}
+
+// returns the contract_id from the public_key 
+#[inline]
+pub fn public_key_to_contract_id(pk: Vec<u8>) -> Result<String, failure::Error> {
+    // 1 byte tag and - 32 bytes for ed25519 (tz1)
+    //                - 33 bytes for secp256k1 (tz2) and p256 (tz3)
+    if pk.len() == 33 || pk.len() == 34 {
+        let tag = pk[0];
+        let hash = blake2b::digest_160(&pk[1..]);
+
+        let contract_id = match tag {
+            0 => {
+                HashType::ContractTz1Hash.bytes_to_string(&hash)
+            }
+            1 => {
+                HashType::ContractTz2Hash.bytes_to_string(&hash)
+            }
+            2 => {
+                HashType::ContractTz3Hash.bytes_to_string(&hash)
+            }
+            _ => bail!("Invalid public key")
+        };
+        Ok(contract_id)
+    } else {
+        bail!("Invalid public key")
+    }
+}
+
+#[inline]
+pub fn chain_id_to_string(chain_id: &ChainId) -> String {
+    HashType::ChainId.bytes_to_string(chain_id)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_contract_id_to_address() -> Result<(), failure::Error> {
+        let result = contract_id_to_address("0000cf49f66b9ea137e11818f2a78b4b6fc9895b4e50")?;
+        assert_eq!(result, hex::decode("0000cf49f66b9ea137e11818f2a78b4b6fc9895b4e50")?);
+
+        let result = contract_id_to_address("tz1Y68Da76MHixYhJhyU36bVh7a8C9UmtvrR")?;
+        assert_eq!(result, hex::decode("00008890efbd6ca6bbd7771c116111a2eec4169e0ed8")?);
+
+        let result = contract_id_to_address("tz2LBtbMMvvguWQupgEmtfjtXy77cHgdr5TE")?;
+        assert_eq!(result, hex::decode("0001823dd85cdf26e43689568436e43c20cc7c89dcb4")?);
+
+        let result = contract_id_to_address("tz3e75hU4EhDU3ukyJueh5v6UvEHzGwkg3yC")?;
+        assert_eq!(result, hex::decode("0002c2fe98642abd0b7dd4bc0fc42e0a5f7c87ba56fc")?);
+
+        let result = contract_id_to_address("KT1NrjjM791v7cyo6VGy7rrzB3Dg3p1mQki3")?;
+        assert_eq!(result, hex::decode("019c96e27f418b5db7c301147b3e941b41bd224fe400")?);
+
+        Ok(())
+    }
+}

--- a/rpc/src/encoding/conversions.rs
+++ b/rpc/src/encoding/conversions.rs
@@ -4,6 +4,11 @@ use crypto::hash::{ChainId, HashType};
 use crypto::blake2b;
 use storage::context_storage::ContractAddress;
 
+/// convert contract id to contract address
+/// 
+/// # Arguments
+/// 
+/// * `contract_id` - contract id (tz... or KT1...)
 #[inline]
 pub fn contract_id_to_address(contract_id: &str) -> Result<ContractAddress, failure::Error> {
     let contract_address = {
@@ -40,7 +45,11 @@ pub fn contract_id_to_address(contract_id: &str) -> Result<ContractAddress, fail
     Ok(contract_address)
 }
 
-// returns the contract_id from the public_key 
+/// convert public key byte string to contract id
+/// 
+/// # Arguments
+/// 
+/// * `pk` - public key in byte string format
 #[inline]
 pub fn public_key_to_contract_id(pk: Vec<u8>) -> Result<String, failure::Error> {
     // 1 byte tag and - 32 bytes for ed25519 (tz1)

--- a/rpc/src/encoding/conversions.rs
+++ b/rpc/src/encoding/conversions.rs
@@ -1,26 +1,8 @@
 use failure::bail;
 
-use crypto::hash::{BlockHash, ChainId, HashType};
+use crypto::hash::{ChainId, HashType};
 use crypto::blake2b;
-use storage::{BlockStorage, BlockStorageReader};
 use storage::context_storage::ContractAddress;
-use storage::persistent::PersistentStorage;
-
-/// Get block has bytes from block hash or block level
-#[inline]
-pub fn block_id_to_block_hash(block_id: &str, persistent_storage: &PersistentStorage) -> Result<BlockHash, failure::Error> {
-    
-    let block_storage = BlockStorage::new(persistent_storage);
-    let block_hash = match block_id.parse() {
-        Ok(value) =>  match block_storage.get_by_block_level(value)? {
-            Some(current_head) => current_head.hash,
-            None => vec![]
-        },
-        Err(_e) => HashType::BlockHash.string_to_bytes(block_id)?   
-    };
-
-    Ok(block_hash)
-}
 
 #[inline]
 pub fn contract_id_to_address(contract_id: &str) -> Result<ContractAddress, failure::Error> {
@@ -89,7 +71,6 @@ pub fn public_key_to_contract_id(pk: Vec<u8>) -> Result<String, failure::Error> 
 pub fn chain_id_to_string(chain_id: &ChainId) -> String {
     HashType::ChainId.bytes_to_string(chain_id)
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/rpc/src/encoding/mod.rs
+++ b/rpc/src/encoding/mod.rs
@@ -1,6 +1,7 @@
 pub mod base_types;
 pub mod monitor;
 pub mod chain;
+pub mod conversions;
 pub mod context;
 
 #[cfg(test)]

--- a/rpc/src/helpers.rs
+++ b/rpc/src/helpers.rs
@@ -429,8 +429,7 @@ impl RightsContextData {
 
         // iterate through all the owners,the roll_num is the last component of the key, decode the value (it is a public key) to get the public key hash address (tz1...)
         for (key, value) in data.into_iter() {
-            let key_split = key.split('/').collect::<Vec<_>>();
-            let roll_num = key_split[key_split.len() - 1];
+            let roll_num = key.split('/').last().unwrap();
 
             // the values are public keys
             if let Bucket::Exists(pk) = value {
@@ -612,7 +611,6 @@ impl RightsParams {
 
         // get block header timestamp form block_id
         let block_timestamp = get_block_timestamp_by_level(block_level.try_into()?, persistent_storage)?;
-        //let block_timestamp = get_block_header_timestamp(param_block_id, persistent_storage, state)?;
 
         Ok(Self::new(
             param_chain_id.to_string(),
@@ -639,11 +637,7 @@ impl RightsParams {
     #[inline]
     pub fn get_estimated_time(&self, constants: &RightsConstants, level: Option<i64>) -> Option<String> {
         // if is cycle then level is provided as parameter else use prepared timestamp_level
-        let timestamp_level = if let Some(l) = level {
-            l
-        } else {
-            self.timestamp_level
-        };
+        let timestamp_level = level.unwrap_or(self.timestamp_level);
 
         //check if estimated time is computed and convert from raw epoch time to rfc3339 format
         if self.block_level <= timestamp_level {

--- a/rpc/src/server/service.rs
+++ b/rpc/src/server/service.rs
@@ -475,7 +475,7 @@ mod fns {
     use itertools::Itertools;
     use serde::{Deserialize, Serialize};
 
-    use failure::{bail};
+    use failure::{bail, format_err};
     
     use shell::shell_channel::BlockApplied;
     use shell::stats::memory::{Memory, MemoryData, MemoryStatsResult};
@@ -772,7 +772,7 @@ mod fns {
 
         // order descending by delegate public key hash address hex byte string
         for delegate in endorsers_slots.keys().sorted().rev() {
-            let delegate_data = endorsers_slots.get(delegate).unwrap();
+            let delegate_data = endorsers_slots.get(delegate).ok_or(format_err!("missing EndorserSlots"))?;
 
             // prepare delegate contract id
             let delegate_contract_id = delegate_data.contract_id().to_string();


### PR DESCRIPTION
Refactor endorsing(baking) rights RPC

Add more comments

Create documentation that will be generated by cargo doc

Parse block_id url path parameter on one place. That mean that 'head' can be used as parameter input in all RPC calls and it return block hash byte string from current RPC collected state so current block head info will be outputted from RPC calls