### PR TITLE
Baking rights and Endorsing rights optimizations

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -83,7 +83,8 @@ steps:
     - tezos-node-bootstrap --bootstrap
 
 - name: wrk-performance-test
-  image: simplestakingcom/tezos-node-bootstrap:latest
+  image: simplestakingcom/tezos-node-bootstrap:wrk1
+  pull: always
   user: root
   commands:
     - tezos-node-bootstrap --performance-test 

--- a/rpc/src/helpers.rs
+++ b/rpc/src/helpers.rs
@@ -801,6 +801,7 @@ pub type TezosPRNGResult = Result<(i32, RandomSeedState), TezosPRNGError>;
 /// * `offset` - For baking priority, for endorsing slot
 /// 
 /// Return first random sequence state to use in [get_prng_number](`get_prng_number`)
+#[inline]
 pub fn init_prng(cycle_data: &RightsContextData, constants: &RightsConstants, use_string_bytes: &[u8], level: i32, offset: i32) -> Result<RandomSeedState, failure::Error> {
     // a safe way to convert betwwen types is to use try_from
     let nonce_size = usize::try_from(*constants.nonce_length())?;
@@ -831,6 +832,7 @@ pub fn init_prng(cycle_data: &RightsContextData, constants: &RightsConstants, us
 /// * `bound` - Last possible roll nuber that have meaning to be generated taken from [RightsContextData.last_roll](`RightsContextData.last_roll`).
 /// 
 /// Return pseudo random generated roll number and RandomSeedState for next roll generation if the roll provided is missing from the roll list
+#[inline]
 pub fn get_prng_number(state: RandomSeedState, bound: i32) -> TezosPRNGResult {
     if bound < 1 {
         return Err(TezosPRNGError::BoundNotCorrect{bound: bound})

--- a/rpc/src/helpers.rs
+++ b/rpc/src/helpers.rs
@@ -813,14 +813,20 @@ pub fn init_prng(cycle_data: &RightsContextData, constants: &RightsConstants, us
     let cycle_position: i32 = level_position(level.into(), blocks_per_cycle)?.try_into()?;
 
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
-    let rd = blake2b::digest_256(&merge_slices!(&state, &zero_bytes, use_string_bytes, &cycle_position.to_be_bytes())).to_vec();
+    let mut rd = blake2b::digest_256(&merge_slices!(&state, &zero_bytes, use_string_bytes, &cycle_position.to_be_bytes())).to_vec();
     
     // take the 4 highest bytes and xor them with the priority/slot (offset)
     let higher = num_from_slice!(rd, 0, i32) ^ offset;
     
     // set the 4 highest bytes to the result of the xor operation
-    let sequence = blake2b::digest_256(&merge_slices!(&higher.to_be_bytes(), &rd[4..])).to_vec();
+    //let sequence = blake2b::digest_256(&merge_slices!(&higher.to_be_bytes(), &rd[4..]));
+    let higher_b = higher.to_be_bytes();
+    rd[0] = higher_b[0];
+    rd[1] = higher_b[1];
+    rd[2] = higher_b[2];
+    rd[3] = higher_b[3];
 
+    let sequence = blake2b::digest_256(&rd);
     Ok(sequence)
 }
 

--- a/rpc/src/helpers.rs
+++ b/rpc/src/helpers.rs
@@ -813,20 +813,14 @@ pub fn init_prng(cycle_data: &RightsContextData, constants: &RightsConstants, us
     let cycle_position: i32 = level_position(level.into(), blocks_per_cycle)?.try_into()?;
 
     // take the state (initially the random seed), zero bytes, the use string and the blocks position in the cycle as bytes, merge them together and hash the result
-    let mut rd = blake2b::digest_256(&merge_slices!(&state, &zero_bytes, use_string_bytes, &cycle_position.to_be_bytes())).to_vec();
+    let rd = blake2b::digest_256(&merge_slices!(&state, &zero_bytes, use_string_bytes, &cycle_position.to_be_bytes())).to_vec();
     
     // take the 4 highest bytes and xor them with the priority/slot (offset)
     let higher = num_from_slice!(rd, 0, i32) ^ offset;
     
     // set the 4 highest bytes to the result of the xor operation
-    //let sequence = blake2b::digest_256(&merge_slices!(&higher.to_be_bytes(), &rd[4..]));
-    let higher_b = higher.to_be_bytes();
-    rd[0] = higher_b[0];
-    rd[1] = higher_b[1];
-    rd[2] = higher_b[2];
-    rd[3] = higher_b[3];
-
-    let sequence = blake2b::digest_256(&rd);
+    let sequence = blake2b::digest_256(&merge_slices!(&higher.to_be_bytes(), &rd[4..]));
+    
     Ok(sequence)
 }
 

--- a/rpc/src/server/service.rs
+++ b/rpc/src/server/service.rs
@@ -3,6 +3,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::convert::TryInto;
+use std::time::{Duration, Instant};
 
 use failure::{bail, format_err};
 use itertools::Itertools;
@@ -104,14 +105,33 @@ pub(crate) fn check_and_get_baking_rights(chain_id: &str, block_id: &str, level:
         Some(val) => val.try_into()?,
         None => bail!("Block level not found")
     };
+    let now = Instant::now();
 
     let constants: RightsConstants = get_and_parse_rights_constants(&chain_id, &block_id, block_level, list.clone(), persistent_storage, state)?;
+    
+    let elapsed = now.elapsed();
+    let sec = (elapsed.as_secs() as f64) + (elapsed.subsec_nanos() as f64 / 1000_000_000.0);
+    println!("Getting(from context) and Parsing baking rights constants Duration in seconds: {}", sec);
 
+    let now_params = Instant::now();
     let params: RightsParams = RightsParams::parse_rights_parameters(chain_id, level, delegate, cycle, max_priority, has_all, block_level, &constants, persistent_storage, true)?;
+    let elapsed_params = now_params.elapsed();
+    let sec_params = (elapsed_params.as_secs() as f64) + (elapsed_params.subsec_nanos() as f64 / 1000_000_000.0);
+    println!("Parsing baking rights parameters Duration in seconds: {}", sec_params);
 
+    let now_context_data = Instant::now();
     let context_data: RightsContextData = RightsContextData::prepare_context_data_for_rights(params.clone(), constants.clone(), list)?;
+    let elapsed_context_data = now_context_data.elapsed();
+    let sec_context_data = (elapsed_context_data.as_secs() as f64) + (elapsed_context_data.subsec_nanos() as f64 / 1000_000_000.0);
+    println!("Preparing context data for baking rights Duration in seconds: {}", sec_context_data);
 
-    get_baking_rights(&context_data, &params, &constants)
+    let now_algo = Instant::now();
+    let ret = get_baking_rights(&context_data, &params, &constants);
+    let elapsed_algo = now_algo.elapsed();
+    let sec_algo = (elapsed_algo.as_secs() as f64) + (elapsed_algo.subsec_nanos() as f64 / 1000_000_000.0);
+    println!("Algorithm Duration in seconds: {}", sec_algo);
+
+    ret
 }
 
 /// Use prepared data to generate baking rights
@@ -121,6 +141,7 @@ pub(crate) fn check_and_get_baking_rights(chain_id: &str, block_id: &str, level:
 /// * `context_data` - Data from context list used in baking and endorsing rights generation filled in [RightsContextData](RightsContextData::prepare_context_data_for_rights).
 /// * `parameters` - Parameters created by [RightsParams](RightsParams::parse_rights_parameters).
 /// * `constants` - Context constants used in baking and endorsing rights [`get_and_parse_rights_constants`].
+#[inline]
 pub(crate) fn get_baking_rights(context_data: &RightsContextData, parameters: &RightsParams, constants: &RightsConstants) -> Result<Option< RpcResponseData >, failure::Error> {
     let mut baking_rights = Vec::<BakingRights>::new();
 
@@ -140,16 +161,16 @@ pub(crate) fn get_baking_rights(context_data: &RightsContextData, parameters: &R
             let estimated_timestamp = timestamp + seconds_to_add;
 
             // assign rolls goes here
-            let level_baking_rights = baking_rights_assign_rolls(&parameters, &constants, &context_data, level, estimated_timestamp)?;
+            baking_rights = baking_rights_assign_rolls(&parameters, &constants, &context_data, level, estimated_timestamp, baking_rights)?;
 
-            baking_rights = merge_slices!(&baking_rights, &level_baking_rights);
+            // baking_rights = merge_slices!(&baking_rights, &level_baking_rights);
         }
     } else {
         let level = *parameters.requested_level();
         let seconds_to_add = (level - block_level).abs() * time_between_blocks[0];
         let estimated_timestamp = timestamp + seconds_to_add;
         // assign rolls goes here
-        baking_rights = baking_rights_assign_rolls(&parameters, &constants, &context_data, level, estimated_timestamp)?;
+        baking_rights = baking_rights_assign_rolls(&parameters, &constants, &context_data, level, estimated_timestamp, baking_rights)?;
     }
 
     // if there is some delegate specified, retrive his priorities
@@ -171,11 +192,11 @@ pub(crate) fn get_baking_rights(context_data: &RightsContextData, parameters: &R
 /// * `estimated_head_timestamp` - Estimated time of baking, is set to None if in past relative to block_id.
 ///
 /// Baking priorities are are assigned to Roles, the default behavior is to include only the top priority for the delegate
-fn baking_rights_assign_rolls(parameters: &RightsParams, constants: &RightsConstants, context_data: &RightsContextData, level: i64, estimated_head_timestamp: i64) -> Result<Vec<BakingRights>, failure::Error>{
+#[inline]
+fn baking_rights_assign_rolls(parameters: &RightsParams, constants: &RightsConstants, context_data: &RightsContextData, level: i64, estimated_head_timestamp: i64, mut baking_rights: Vec<BakingRights>) -> Result<Vec<BakingRights>, failure::Error>{
     const BAKING_USE_STRING: &[u8] = b"level baking:";
 
     // hashset is defined to keep track of the delegates with priorities allready assigned
-    let mut baking_rights = Vec::<BakingRights>::new();
     let mut assigned = HashSet::new();
 
     let time_between_blocks = constants.time_between_blocks();
@@ -183,6 +204,8 @@ fn baking_rights_assign_rolls(parameters: &RightsParams, constants: &RightsConst
     let max_priority = *parameters.max_priority();
     let has_all = parameters.has_all();
     let block_level = *parameters.block_level();
+    let last_roll = *context_data.last_roll();
+    let rolls_map = context_data.rolls();
 
     for priority in 0..max_priority {
         // draw the rolls for the requested parameters
@@ -191,9 +214,9 @@ fn baking_rights_assign_rolls(parameters: &RightsParams, constants: &RightsConst
         let mut state = init_prng(&context_data, &constants, BAKING_USE_STRING, level.try_into()?, priority.try_into()?)?;
 
         loop {
-            let (random_num, sequence) = get_prng_number(state, *context_data.last_roll())?;
+            let (random_num, sequence) = get_prng_number(state, last_roll)?;
 
-            if let Some(d) = context_data.rolls().get(&random_num) {
+            if let Some(d) = rolls_map.get(&random_num) {
                 delegate_to_assign = d;
                 break;
             } else {


### PR DESCRIPTION
Removed the merge_slices macro where it was called more then once (rights for a whole cycle). Merge_slices caused to many unnecessary allocations.

See test in drone CI (when finished running) to compare the result of the optimization.
