### PR TITLE
Downgrade docker compose file version to 2 (#190)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "2"
 services:
 
   node:


### PR DESCRIPTION
To enable better linux distribution support docker-compose yml version was set to "2".