### PR TITLE
Remove bitvec dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,13 +132,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "1.2.1"
+name = "bit-vec"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "bitvec"
-version = "0.9.0"
+name = "bitflags"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2522,7 +2522,7 @@ dependencies = [
 name = "tezos_encoding"
 version = "0.1.0"
 dependencies = [
- "bitvec 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bit-vec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2924,8 +2924,8 @@ dependencies = [
 "checksum base64 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 "checksum bincode 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
 "checksum bindgen 0.49.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4c07087f3d5731bf3fb375a81841b99597e25dc11bd3bc72d16d43adf6624a6e"
+"checksum bit-vec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5f0dc55f2d8a1a85650ac47858bb001b4c0dd73d79e3c455a842925e68d29cd3"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
-"checksum bitvec 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "cfadef5c4e2c2e64067b9ecc061179f12ac7ec65ba613b1f60f3972bbada1f5b"
 "checksum blake2b_simd 0.5.10 (registry+https://github.com/rust-lang/crates.io-index)" = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"

--- a/tezos/encoding/Cargo.toml
+++ b/tezos/encoding/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Tomas Sedlak <tomas.sedlak@simplestaking.com>"]
 edition = "2018"
 
 [dependencies]
-bitvec = "0.9.0"
+bit-vec = "0.6.2"
 byteorder = "1.3.2"
 bytes = "0.5"
 chrono = "0.4.9"

--- a/tezos/encoding/src/binary_reader.rs
+++ b/tezos/encoding/src/binary_reader.rs
@@ -3,13 +3,13 @@
 
 //! Tezos binary data reader.
 
-use bitvec::{Bits, BitVec};
+use bit_vec::BitVec;
 use bytes::Buf;
 use bytes::buf::ext::BufExt;
 use failure::Fail;
 use serde::de::Error as SerdeError;
 
-use crate::bit_utils::{BitReverse, BitTrim, ToBytes};
+use crate::bit_utils::{BitReverse, Bits, BitTrim, ToBytes};
 use crate::de;
 use crate::encoding::{Encoding, Field, SchemaType};
 use crate::types::{self, Value};
@@ -245,7 +245,7 @@ impl BinaryReader {
                     }
                     Ok(Value::String(format!("{:x}", num)))
                 } else {
-                    let mut bits: BitVec<bitvec::BigEndian, u8> = BitVec::new();
+                    let mut bits = BitVec::new();
                     for bit_idx in 0..6 {
                         bits.push(byte.get(bit_idx));
                     }
@@ -281,7 +281,7 @@ impl BinaryReader {
                 }
             }
             Encoding::Mutez => {
-                let mut bits: BitVec<bitvec::BigEndian, u8> = BitVec::new();
+                let mut bits = BitVec::new();
 
                 let mut has_next_byte = true;
                 while has_next_byte {
@@ -342,7 +342,7 @@ mod tests {
 
     use serde::{Deserialize, Serialize};
 
-    use crate::{de, binary_writer};
+    use crate::{binary_writer, de};
     use crate::encoding::{Tag, TagMap};
     use crate::ser::Serializer;
     use crate::types::BigInt;

--- a/tezos/encoding/src/binary_writer.rs
+++ b/tezos/encoding/src/binary_writer.rs
@@ -6,12 +6,12 @@
 use std::cmp;
 use std::mem::size_of;
 
-use bitvec::{Bits, BitVec};
+use bit_vec::BitVec;
 use byteorder::{BigEndian, WriteBytesExt};
 use bytes::BufMut;
 use serde::ser::{Error as SerdeError, Serialize};
 
-use crate::bit_utils::BitTrim;
+use crate::bit_utils::{Bits, BitTrim};
 use crate::encoding::{Encoding, Field, SchemaType};
 use crate::ser::{Error, Serializer};
 use crate::types::{self, Value};
@@ -428,7 +428,7 @@ fn encode_z(data: &mut Vec<u8>, value: &str) -> Result<usize, Error> {
         // At the beginning we have to process first 6 bits because we have to indicate
         // continuation of bit chunks and to set one bit to indicate numeric sign (0-positive, 1-negative).
         // Then the algorithm continues by processing 7 bit chunks.
-        let mut bits: BitVec<bitvec::BigEndian, u8> = bytes.into();
+        let mut bits = BitVec::from_bytes(&bytes);
         bits = bits.trim_left();
 
         let mut n: u8 = if negative { 0xC0 } else { 0x80 };

--- a/tezos/encoding/src/bit_utils.rs
+++ b/tezos/encoding/src/bit_utils.rs
@@ -1,17 +1,111 @@
-use bitvec::{BitVec, Cursor, Bits};
+// Copyright (c) SimpleStaking and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use std::fmt::{Binary, Debug, Display, LowerHex, UpperHex};
+use std::mem::size_of;
+use std::ops::{BitAnd, BitAndAssign, BitOrAssign, Not, Shl, ShlAssign, Shr, ShrAssign};
+
+use bit_vec::BitVec;
+
+/// A trait for types that can be used as direct storage of bits.
+///
+/// This trait must only be implemented on unsigned integer primitives.
+///
+/// The dependency on `Sealed`, a crate-private trait, ensures that this trait
+/// can only ever be implemented locally, and no downstream crates are able to
+/// implement it on new types.
+pub trait Bits:
+    Binary
+    + BitAnd<Self, Output=Self>
+    + BitAndAssign<Self>
+    + BitOrAssign<Self>
+    //  Permit indexing into a generic array
+    + Copy
+    + Debug
+    + Display
+    //  Permit testing a value against 1 in `get()`.
+    + Eq
+    //  Rust treats numeric literals in code as vaguely typed and does not make
+    //  them concrete until long after trait expansion, so this enables building
+    //  a concrete Self value from a numeric literal.
+    + From<u8>
+    + LowerHex
+    + Not<Output=Self>
+    + Shl<u8, Output=Self>
+    + ShlAssign<u8>
+    + Shr<u8, Output=Self>
+    + ShrAssign<u8>
+    //  Allow direct access to a concrete implementor type.
+    + Sized
+    + UpperHex
+{
+    /// The width in bits of this type.
+    const WIDTH: u8 = size_of::<Self>() as u8 * 8;
+
+    /// The number of bits required to *index* the type. This is always
+    /// log<sub>2</sub> of the type width.
+    ///
+    /// Incidentally, this can be computed as `size_of().trailing_zeros()` once
+    /// that becomes a valid constexpr.
+    const BITS: u8; // = size_of::<Self>().trailing_zeros() as u8;
+
+    /// The bitmask to turn an arbitrary usize into the bit index. Bit indices
+    /// are always stored in the lowest bits of an index value.
+    const MASK: u8 = Self::WIDTH - 1;
+
+    /// The maximum number of this type that can be held in a `BitVec`.
+    const MAX_ELT: usize = core::usize::MAX >> Self::BITS;
+
+    /// Set a specific bit in an element to a given value.
+    fn set(&mut self, place: u8, value: bool) {
+        assert!(place <= Self::MASK, "Index out of range");
+        //  Blank the selected bit
+        *self &= !(Self::from(1u8) << place);
+        //  Set the selected bit
+        *self |= Self::from(value as u8) << place;
+    }
+
+    /// Get a specific bit in an element.
+    fn get(&self, place: u8) -> bool {
+        assert!(place <= Self::MASK, "Index out of range");
+        //  Shift down so the targeted bit is LSb, then blank all other bits.
+        (*self >> place) & Self::from(1) == Self::from(1)
+    }
+
+    /// Rust doesn’t (as far as I know) have a way to render a typename at
+    /// runtime, so this constant holds the typename of the primitive for
+    /// printing by Debug.
+    #[doc(hidden)]
+    const TY: &'static str;
+}
+
+impl Bits for u8 {
+    const BITS: u8 = 3;
+
+    const TY: &'static str = "u8";
+}
+
+impl Bits for u16 {
+    const BITS: u8 = 4;
+
+    const TY: &'static str = "u16";
+}
+
+impl Bits for u32 {
+    const BITS: u8 = 5;
+
+    const TY: &'static str = "u32";
+}
 
 pub trait BitReverse {
     fn reverse(&self) -> Self;
 }
 
-impl <E,T> BitReverse for BitVec<E,T>
-    where
-        E: Cursor,
-        T: Bits
+impl BitReverse for BitVec
 {
     #[inline]
-    fn reverse(&self) -> BitVec<E,T> {
-        let mut reversed: BitVec<E,T> = BitVec::new();
+    fn reverse(&self) -> BitVec {
+        let mut reversed = BitVec::new();
         for bit in self.iter().rev() {
             reversed.push(bit)
         }
@@ -24,13 +118,10 @@ pub trait BitTrim {
     fn trim_left(&self) -> Self;
 }
 
-impl <E,T> BitTrim for BitVec<E,T>
-    where
-        E: Cursor,
-        T: Bits
+impl BitTrim for BitVec
 {
-    fn trim_left(&self) -> BitVec<E,T> {
-        let mut trimmed: BitVec<E,T> = BitVec::new();
+    fn trim_left(&self) -> BitVec {
+        let mut trimmed: BitVec = BitVec::new();
 
         let mut notrim = false;
         for bit in self.iter() {
@@ -49,10 +140,7 @@ pub trait ToBytes {
     fn to_byte_vec(&self) -> Vec<u8>;
 }
 
-impl <E,T> ToBytes for BitVec<E,T>
-    where
-        E: Cursor,
-        T: Bits
+impl ToBytes for BitVec
 {
     fn to_byte_vec(&self) -> Vec<u8> {
         let mut bytes = vec![];
@@ -72,5 +160,56 @@ impl <E,T> ToBytes for BitVec<E,T>
         }
         bytes.reverse();
         bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reverse() {
+        let mut bits = BitVec::new();
+        bits.push(false);   // 0
+        bits.push(false);   // 1
+        bits.push(false);   // 2
+        bits.push(true);    // 3
+        bits.push(true);    // 4
+        bits.push(true);    // 5
+        bits.push(false);   // 6
+        bits.push(true);    // 7
+        bits.push(false);   // 8
+        assert_eq!(vec![0, 184], bits.reverse().to_byte_vec());
+    }
+
+    #[test]
+    fn trim_left() {
+        let mut bits = BitVec::new();
+        bits.push(false);   // 0
+        bits.push(false);   // 1
+        bits.push(false);   // 2
+        bits.push(true);    // 3
+        bits.push(true);    // 4
+        bits.push(true);    // 5
+        bits.push(false);   // 6
+        bits.push(true);    // 7
+        assert_eq!(vec![29], bits.trim_left().to_byte_vec());
+    }
+
+    #[test]
+    fn to_byte_vec() {
+        let mut bits = BitVec::new();
+        bits.push(true);    // 0
+        bits.push(false);   // 1
+        bits.push(false);   // 2
+        bits.push(true);    // 3
+        bits.push(true);    // 4
+        bits.push(true);    // 5
+        bits.push(false);   // 6
+        bits.push(true);    // 7
+        assert_eq!(vec![157], bits.to_byte_vec());
+
+        bits.push(false);   // 8
+        assert_eq!(vec![1, 58], bits.to_byte_vec());
     }
 }

--- a/tezos/interop/src/lib.rs
+++ b/tezos/interop/src/lib.rs
@@ -11,7 +11,7 @@
 ///
 /// It can be then easily awaited in rust:
 ///
-/// ```
+/// ```rust, no_run
 /// use tezos_interop::runtime::OcamlResult;
 /// use tezos_interop::runtime;
 /// use ocaml::{Str};


### PR DESCRIPTION
We use bitvec in encoding (AFAIK only in Zarith encoding implementation). This crate is painful to use, as their
policies on version updates and older version support renders our libraries useless, because they cannot be imported
to any other code, and also renders `cargo install` non-functional.
Trying to import any tezedge library or calling `cargo install` will result in error:
```
error: failed to select a version for the requirement `bitvec = "^0.9.0"`
candidate versions found which didn't match: 0.17.4
```