### PR TITLE
Feature/TE-201: New Interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Resolved various clippy warnings/errors.
 - Drone test runs offline with carthagenet-snapshoted nodes.
+- New ocaml ffi - `ocaml-rs` was replaced with custom new library based on `ocaml-oxide` to get GC under control and better performance
 
 ### Deprecated
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,12 +1683,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ab52be62400ca80aa00285d25253d7f7c437b7375c4de678f5405d3afe82ca5"
 
 [[package]]
-name = "ocaml"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6030f4e6d82ed5a401021c654a0af51c91b166f6879532ab4cdd195e7b83179"
-
-[[package]]
 name = "once_cell"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2726,12 +2720,12 @@ dependencies = [
  "failure",
  "hex",
  "lazy_static",
- "ocaml",
  "serde 1.0.114",
  "serde_json",
  "slog",
  "tezos_encoding",
  "tezos_messages",
+ "znfe",
 ]
 
 [[package]]
@@ -2786,7 +2780,6 @@ dependencies = [
  "futures",
  "hex",
  "lazy_static",
- "ocaml",
  "os_type",
  "serde 1.0.114",
  "serde_json",
@@ -2796,14 +2789,15 @@ dependencies = [
  "tezos_context",
  "tezos_interop_callback",
  "tezos_messages",
+ "znfe",
 ]
 
 [[package]]
 name = "tezos_interop_callback"
 version = "0.3.0"
 dependencies = [
- "ocaml",
  "tezos_context",
+ "znfe",
 ]
 
 [[package]]
@@ -3204,3 +3198,8 @@ dependencies = [
  "podio",
  "time",
 ]
+
+[[package]]
+name = "znfe"
+version = "0.1.0"
+source = "git+https://github.com/tizoc/znfe.git?tag=v0.1.0#7da9b0d1c927a92bd10565e7101025e8c44d7d4d"

--- a/tezos/api/Cargo.toml
+++ b/tezos/api/Cargo.toml
@@ -10,7 +10,7 @@ enum-iterator = "0.6"
 failure = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 lazy_static = "1.4"
-ocaml = "0.9.3"
+znfe = { git = "https://github.com/tizoc/znfe.git", tag="v0.1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slog = "2.5"

--- a/tezos/client/src/client.rs
+++ b/tezos/client/src/client.rs
@@ -4,7 +4,7 @@
 use crypto::hash::{ChainId, ContextHash, ProtocolHash};
 use tezos_api::ffi::{ApplyBlockError, ApplyBlockRequest, ApplyBlockResponse, BeginConstructionError, BeginConstructionRequest, CommitGenesisResult, ContextDataError, GenesisChain, GetDataError, InitProtocolContextResult, JsonRpcResponse, PatchContext, PrevalidatorWrapper, ProtocolJsonRpcRequest, ProtocolOverrides, ProtocolRpcError, TezosGenerateIdentityError, TezosRuntimeConfiguration, TezosRuntimeConfigurationError, TezosStorageInitError, ValidateOperationError, ValidateOperationRequest, ValidateOperationResponse, ComputePathError, ComputePathRequest, ComputePathResponse};
 use tezos_api::identity::Identity;
-use tezos_interop::{ffi, runtime};
+use tezos_interop::ffi;
 
 /// Override runtime configuration for OCaml runtime
 pub fn change_runtime_configuration(settings: TezosRuntimeConfiguration) -> Result<(), TezosRuntimeConfigurationError> {
@@ -179,5 +179,5 @@ pub fn decode_context_data(protocol_hash: ProtocolHash, key: Vec<String>, data: 
 }
 
 pub fn shutdown_runtime() {
-    runtime::shutdown();
+    ffi::shutdown();
 }

--- a/tezos/interop/Cargo.toml
+++ b/tezos/interop/Cargo.toml
@@ -9,7 +9,7 @@ failure = "0.1"
 futures = { version = "0.3", features = ["thread-pool"] }
 hex = "0.4"
 lazy_static = "1.4"
-ocaml = "0.9.3"
+znfe = { git = "https://github.com/tizoc/znfe.git", tag="v0.1.0" }
 serde_json = "1.0"
 # local dependencies
 tezos_api = { path = "../api" }

--- a/tezos/interop/build.rs
+++ b/tezos/interop/build.rs
@@ -238,8 +238,8 @@ fn main() {
     rerun_if_ocaml_file_changes();
 
     println!("cargo:rustc-link-search={}", &out_dir);
-    println!("cargo:rustc-link-lib=dylib=tezos");
     println!("cargo:rustc-link-lib=dylib=tezos_interop_callback");
+    println!("cargo:rustc-link-lib=dylib=tezos");
     println!("cargo:rerun-if-env-changed=OCAML_LIB");
     println!("cargo:rerun-if-env-changed=UPDATE_GIT");
 }

--- a/tezos/interop/build.rs
+++ b/tezos/interop/build.rs
@@ -13,7 +13,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
 const GIT_REPO_URL: &str = "https://gitlab.com/simplestaking/tezos.git";
-const GIT_COMMIT_HASH: &str = "4f4930165f08bc0ae61ac496875e3742743be41e";
+const GIT_COMMIT_HASH: &str = "298e26ffb8b60a5541c5d308bbac78e412699233";
 const GIT_RELEASE_DISTRIBUTIONS_FILE: &str = "lib_tezos/libtezos-ffi-distribution-summary.json";
 const GIT_REPO_DIR: &str = "lib_tezos/src";
 

--- a/tezos/interop/lib_tezos/libtezos-ffi-distribution-summary.json
+++ b/tezos/interop/lib_tezos/libtezos-ffi-distribution-summary.json
@@ -1,162 +1,141 @@
-[
-  {
-    "id": 65650,
+[{
+    "id": 67059,
     "name": "libtezos-ffi-centos8.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/a9c1c54f128abba27ed1568ef5ab9e00/libtezos-ffi-centos8.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/a9c1c54f128abba27ed1568ef5ab9e00/libtezos-ffi-centos8.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/97094733bc3403391892fcb74402cd0a/libtezos-ffi-centos8.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/97094733bc3403391892fcb74402cd0a/libtezos-ffi-centos8.so.sha256",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65649,
+}, {
+    "id": 67058,
     "name": "libtezos-ffi-centos8.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/410e1dfd1e4c7e35b5d33ffd0a79fc44/libtezos-ffi-centos8.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/410e1dfd1e4c7e35b5d33ffd0a79fc44/libtezos-ffi-centos8.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/cbd393d9ed549ef63412e64d47a4cb1f/libtezos-ffi-centos8.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/cbd393d9ed549ef63412e64d47a4cb1f/libtezos-ffi-centos8.so",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65648,
+}, {
+    "id": 67057,
     "name": "libtezos-ffi-centos7.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/3031acd96ccff02667d6b01204591172/libtezos-ffi-centos7.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/3031acd96ccff02667d6b01204591172/libtezos-ffi-centos7.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/f00bbc9f7b5aac28580c6be9b1bcf617/libtezos-ffi-centos7.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/f00bbc9f7b5aac28580c6be9b1bcf617/libtezos-ffi-centos7.so.sha256",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65647,
+}, {
+    "id": 67056,
     "name": "libtezos-ffi-centos7.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/22798f91b350e97caeb765faef5be430/libtezos-ffi-centos7.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/22798f91b350e97caeb765faef5be430/libtezos-ffi-centos7.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/59044ba9b4b2dec6a74db8dfd0a59d29/libtezos-ffi-centos7.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/59044ba9b4b2dec6a74db8dfd0a59d29/libtezos-ffi-centos7.so",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65646,
+}, {
+    "id": 67055,
     "name": "libtezos-ffi-opensuse_tumbleweed.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/996aed79b183661a1297695e8feaadc0/libtezos-ffi-opensuse_tumbleweed.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/996aed79b183661a1297695e8feaadc0/libtezos-ffi-opensuse_tumbleweed.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/5974cc261782cfd5864d478f6631efba/libtezos-ffi-opensuse_tumbleweed.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/5974cc261782cfd5864d478f6631efba/libtezos-ffi-opensuse_tumbleweed.so.sha256",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65645,
+}, {
+    "id": 67054,
     "name": "libtezos-ffi-opensuse_tumbleweed.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/220551285b237d0583ef5ee24c2f0bf2/libtezos-ffi-opensuse_tumbleweed.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/220551285b237d0583ef5ee24c2f0bf2/libtezos-ffi-opensuse_tumbleweed.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/2bc79a9b16db67a71ecb349a3180a97d/libtezos-ffi-opensuse_tumbleweed.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/2bc79a9b16db67a71ecb349a3180a97d/libtezos-ffi-opensuse_tumbleweed.so",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65644,
+}, {
+    "id": 67053,
     "name": "libtezos-ffi-opensuse15.1.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/da948c74a497fdb933b14fe1611d8d40/libtezos-ffi-opensuse15.1.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/da948c74a497fdb933b14fe1611d8d40/libtezos-ffi-opensuse15.1.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/f368b200766f241423be9ad478cac764/libtezos-ffi-opensuse15.1.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/f368b200766f241423be9ad478cac764/libtezos-ffi-opensuse15.1.so.sha256",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65643,
+}, {
+    "id": 67052,
     "name": "libtezos-ffi-opensuse15.1.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/98450c95492f4538a4d4c0e6509b4e22/libtezos-ffi-opensuse15.1.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/98450c95492f4538a4d4c0e6509b4e22/libtezos-ffi-opensuse15.1.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/8b87fea2936992b1a56a169813f1969b/libtezos-ffi-opensuse15.1.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/8b87fea2936992b1a56a169813f1969b/libtezos-ffi-opensuse15.1.so",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65642,
+}, {
+    "id": 67049,
     "name": "libtezos-ffi-debian10.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/774048661d34db2add19d8f99973e7d3/libtezos-ffi-debian10.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/774048661d34db2add19d8f99973e7d3/libtezos-ffi-debian10.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/1aefeca2e0e5ddb7b9ad2cd9f29ef496/libtezos-ffi-debian10.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/1aefeca2e0e5ddb7b9ad2cd9f29ef496/libtezos-ffi-debian10.so.sha256",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65641,
+}, {
+    "id": 67048,
     "name": "libtezos-ffi-debian10.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/86a5ad17707c825f28c79138f1b925d4/libtezos-ffi-debian10.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/86a5ad17707c825f28c79138f1b925d4/libtezos-ffi-debian10.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/3e051b0979d396d4a0a2de578b1b3671/libtezos-ffi-debian10.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/3e051b0979d396d4a0a2de578b1b3671/libtezos-ffi-debian10.so",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65640,
+}, {
+    "id": 67047,
     "name": "libtezos-ffi-debian9.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/a3898f27bbf7a6b71880c1860f8281c5/libtezos-ffi-debian9.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/a3898f27bbf7a6b71880c1860f8281c5/libtezos-ffi-debian9.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/be971be24a4ed8cb5ff3c3f7eb84f048/libtezos-ffi-debian9.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/be971be24a4ed8cb5ff3c3f7eb84f048/libtezos-ffi-debian9.so.sha256",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65639,
+}, {
+    "id": 67046,
     "name": "libtezos-ffi-debian9.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/4c829790064e11fb287c95500ef11114/libtezos-ffi-debian9.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/4c829790064e11fb287c95500ef11114/libtezos-ffi-debian9.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/77c115e5f5f53b7a785b1eb139625e89/libtezos-ffi-debian9.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/77c115e5f5f53b7a785b1eb139625e89/libtezos-ffi-debian9.so",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65638,
+}, {
+    "id": 67045,
     "name": "libtezos-ffi-ubuntu20.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/f5f4f77676860c494ca3c8151b464778/libtezos-ffi-ubuntu20.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/f5f4f77676860c494ca3c8151b464778/libtezos-ffi-ubuntu20.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/1c6abc8d7fbfaabd93d2b76ab631ec6f/libtezos-ffi-ubuntu20.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/1c6abc8d7fbfaabd93d2b76ab631ec6f/libtezos-ffi-ubuntu20.so.sha256",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65637,
+}, {
+    "id": 67044,
     "name": "libtezos-ffi-ubuntu20.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/75884afce9f06e9d0b5c68914c2de835/libtezos-ffi-ubuntu20.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/75884afce9f06e9d0b5c68914c2de835/libtezos-ffi-ubuntu20.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/bdcb29c7daa199fa33532009937ad9a4/libtezos-ffi-ubuntu20.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/bdcb29c7daa199fa33532009937ad9a4/libtezos-ffi-ubuntu20.so",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65636,
+}, {
+    "id": 67043,
     "name": "libtezos-ffi-ubuntu19.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/8f9230fbddec7f40ed10cfcf54c72a73/libtezos-ffi-ubuntu19.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/8f9230fbddec7f40ed10cfcf54c72a73/libtezos-ffi-ubuntu19.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/8f229cf4a6d66f00ec131aafa821d18b/libtezos-ffi-ubuntu19.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/8f229cf4a6d66f00ec131aafa821d18b/libtezos-ffi-ubuntu19.so.sha256",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65635,
+}, {
+    "id": 67042,
     "name": "libtezos-ffi-ubuntu19.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/a6c2845f5862d441b6a0f4b625869525/libtezos-ffi-ubuntu19.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/a6c2845f5862d441b6a0f4b625869525/libtezos-ffi-ubuntu19.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/f7f24e14a628159dc5c773b81b03d8a6/libtezos-ffi-ubuntu19.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/f7f24e14a628159dc5c773b81b03d8a6/libtezos-ffi-ubuntu19.so",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65628,
+}, {
+    "id": 67041,
     "name": "libtezos-ffi-ubuntu18.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/d02c6ccd128be35321e4049bfdf6b88a/libtezos-ffi-ubuntu18.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/d02c6ccd128be35321e4049bfdf6b88a/libtezos-ffi-ubuntu18.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/7f41c67866b6aa7cf7d26209337a94ae/libtezos-ffi-ubuntu18.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/7f41c67866b6aa7cf7d26209337a94ae/libtezos-ffi-ubuntu18.so.sha256",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65627,
+}, {
+    "id": 67040,
     "name": "libtezos-ffi-ubuntu18.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/72c2b2f3546094321962220b264ab1b4/libtezos-ffi-ubuntu18.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/72c2b2f3546094321962220b264ab1b4/libtezos-ffi-ubuntu18.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/bd0ed0e614795ff766fb99d6dd7ac1ed/libtezos-ffi-ubuntu18.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/bd0ed0e614795ff766fb99d6dd7ac1ed/libtezos-ffi-ubuntu18.so",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65626,
+}, {
+    "id": 67039,
     "name": "libtezos-ffi-ubuntu16.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/348121b5a5f2c3cc51eacdf19e70d188/libtezos-ffi-ubuntu16.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/348121b5a5f2c3cc51eacdf19e70d188/libtezos-ffi-ubuntu16.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/b38844650d2af2d29d059cf3bb43fd27/libtezos-ffi-ubuntu16.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/b38844650d2af2d29d059cf3bb43fd27/libtezos-ffi-ubuntu16.so.sha256",
     "external": false,
     "link_type": "other"
-  },
-  {
-    "id": 65625,
+}, {
+    "id": 67038,
     "name": "libtezos-ffi-ubuntu16.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/1b39fe715dadee20bd9aeb810d118827/libtezos-ffi-ubuntu16.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/1b39fe715dadee20bd9aeb810d118827/libtezos-ffi-ubuntu16.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/9f99acc7de5839756bc0663fde05e465/libtezos-ffi-ubuntu16.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/9f99acc7de5839756bc0663fde05e465/libtezos-ffi-ubuntu16.so",
     "external": false,
     "link_type": "other"
-  }
-]
+}]

--- a/tezos/interop/lib_tezos/libtezos-ffi-distribution-summary.json
+++ b/tezos/interop/lib_tezos/libtezos-ffi-distribution-summary.json
@@ -1,141 +1,162 @@
-[{
-    "id": 67059,
+[
+  {
+    "id": 67283,
     "name": "libtezos-ffi-centos8.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/97094733bc3403391892fcb74402cd0a/libtezos-ffi-centos8.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/97094733bc3403391892fcb74402cd0a/libtezos-ffi-centos8.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/a192966489c925a216fe7335fe6d7069/libtezos-ffi-centos8.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/a192966489c925a216fe7335fe6d7069/libtezos-ffi-centos8.so.sha256",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67058,
+  },
+  {
+    "id": 67282,
     "name": "libtezos-ffi-centos8.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/cbd393d9ed549ef63412e64d47a4cb1f/libtezos-ffi-centos8.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/cbd393d9ed549ef63412e64d47a4cb1f/libtezos-ffi-centos8.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/c0b99b7df6bc8fa2358b2006789bc4b8/libtezos-ffi-centos8.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/c0b99b7df6bc8fa2358b2006789bc4b8/libtezos-ffi-centos8.so",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67057,
+  },
+  {
+    "id": 67281,
     "name": "libtezos-ffi-centos7.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/f00bbc9f7b5aac28580c6be9b1bcf617/libtezos-ffi-centos7.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/f00bbc9f7b5aac28580c6be9b1bcf617/libtezos-ffi-centos7.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/d93fb9e4d6fe308e276333ee4be2e81f/libtezos-ffi-centos7.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/d93fb9e4d6fe308e276333ee4be2e81f/libtezos-ffi-centos7.so.sha256",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67056,
+  },
+  {
+    "id": 67280,
     "name": "libtezos-ffi-centos7.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/59044ba9b4b2dec6a74db8dfd0a59d29/libtezos-ffi-centos7.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/59044ba9b4b2dec6a74db8dfd0a59d29/libtezos-ffi-centos7.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/48c667b474c19e4321c0b8f7e4ec60a8/libtezos-ffi-centos7.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/48c667b474c19e4321c0b8f7e4ec60a8/libtezos-ffi-centos7.so",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67055,
+  },
+  {
+    "id": 67279,
     "name": "libtezos-ffi-opensuse_tumbleweed.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/5974cc261782cfd5864d478f6631efba/libtezos-ffi-opensuse_tumbleweed.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/5974cc261782cfd5864d478f6631efba/libtezos-ffi-opensuse_tumbleweed.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/7054ddac9a6791dd4198dfdd6dc034c7/libtezos-ffi-opensuse_tumbleweed.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/7054ddac9a6791dd4198dfdd6dc034c7/libtezos-ffi-opensuse_tumbleweed.so.sha256",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67054,
+  },
+  {
+    "id": 67278,
     "name": "libtezos-ffi-opensuse_tumbleweed.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/2bc79a9b16db67a71ecb349a3180a97d/libtezos-ffi-opensuse_tumbleweed.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/2bc79a9b16db67a71ecb349a3180a97d/libtezos-ffi-opensuse_tumbleweed.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/886975749e4d9878374c08ca03ce5bfb/libtezos-ffi-opensuse_tumbleweed.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/886975749e4d9878374c08ca03ce5bfb/libtezos-ffi-opensuse_tumbleweed.so",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67053,
+  },
+  {
+    "id": 67277,
     "name": "libtezos-ffi-opensuse15.1.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/f368b200766f241423be9ad478cac764/libtezos-ffi-opensuse15.1.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/f368b200766f241423be9ad478cac764/libtezos-ffi-opensuse15.1.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/7895487d28d363f52e97aa69aba64616/libtezos-ffi-opensuse15.1.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/7895487d28d363f52e97aa69aba64616/libtezos-ffi-opensuse15.1.so.sha256",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67052,
+  },
+  {
+    "id": 67276,
     "name": "libtezos-ffi-opensuse15.1.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/8b87fea2936992b1a56a169813f1969b/libtezos-ffi-opensuse15.1.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/8b87fea2936992b1a56a169813f1969b/libtezos-ffi-opensuse15.1.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/ce416542d8640b91bb4ef53139247bef/libtezos-ffi-opensuse15.1.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/ce416542d8640b91bb4ef53139247bef/libtezos-ffi-opensuse15.1.so",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67049,
+  },
+  {
+    "id": 67275,
     "name": "libtezos-ffi-debian10.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/1aefeca2e0e5ddb7b9ad2cd9f29ef496/libtezos-ffi-debian10.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/1aefeca2e0e5ddb7b9ad2cd9f29ef496/libtezos-ffi-debian10.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/546a5d2dc5c2ca0269f903651e28f238/libtezos-ffi-debian10.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/546a5d2dc5c2ca0269f903651e28f238/libtezos-ffi-debian10.so.sha256",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67048,
+  },
+  {
+    "id": 67274,
     "name": "libtezos-ffi-debian10.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/3e051b0979d396d4a0a2de578b1b3671/libtezos-ffi-debian10.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/3e051b0979d396d4a0a2de578b1b3671/libtezos-ffi-debian10.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/98f24f03ac3576c28de9c16b00467a8b/libtezos-ffi-debian10.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/98f24f03ac3576c28de9c16b00467a8b/libtezos-ffi-debian10.so",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67047,
+  },
+  {
+    "id": 67273,
     "name": "libtezos-ffi-debian9.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/be971be24a4ed8cb5ff3c3f7eb84f048/libtezos-ffi-debian9.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/be971be24a4ed8cb5ff3c3f7eb84f048/libtezos-ffi-debian9.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/67bd9f53e01afbfd27d01e465726898d/libtezos-ffi-debian9.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/67bd9f53e01afbfd27d01e465726898d/libtezos-ffi-debian9.so.sha256",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67046,
+  },
+  {
+    "id": 67272,
     "name": "libtezos-ffi-debian9.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/77c115e5f5f53b7a785b1eb139625e89/libtezos-ffi-debian9.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/77c115e5f5f53b7a785b1eb139625e89/libtezos-ffi-debian9.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/ec5a35d5c2de31d27c2eeeb4b8110958/libtezos-ffi-debian9.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/ec5a35d5c2de31d27c2eeeb4b8110958/libtezos-ffi-debian9.so",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67045,
+  },
+  {
+    "id": 67271,
     "name": "libtezos-ffi-ubuntu20.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/1c6abc8d7fbfaabd93d2b76ab631ec6f/libtezos-ffi-ubuntu20.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/1c6abc8d7fbfaabd93d2b76ab631ec6f/libtezos-ffi-ubuntu20.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/be1c4e26b476351690bcc35fb42c3baa/libtezos-ffi-ubuntu20.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/be1c4e26b476351690bcc35fb42c3baa/libtezos-ffi-ubuntu20.so.sha256",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67044,
+  },
+  {
+    "id": 67270,
     "name": "libtezos-ffi-ubuntu20.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/bdcb29c7daa199fa33532009937ad9a4/libtezos-ffi-ubuntu20.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/bdcb29c7daa199fa33532009937ad9a4/libtezos-ffi-ubuntu20.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/6226d5c48c4d06d69beecac5a5f6c07d/libtezos-ffi-ubuntu20.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/6226d5c48c4d06d69beecac5a5f6c07d/libtezos-ffi-ubuntu20.so",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67043,
+  },
+  {
+    "id": 67269,
     "name": "libtezos-ffi-ubuntu19.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/8f229cf4a6d66f00ec131aafa821d18b/libtezos-ffi-ubuntu19.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/8f229cf4a6d66f00ec131aafa821d18b/libtezos-ffi-ubuntu19.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/0df98561a079788b2783dc73e4011b43/libtezos-ffi-ubuntu19.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/0df98561a079788b2783dc73e4011b43/libtezos-ffi-ubuntu19.so.sha256",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67042,
+  },
+  {
+    "id": 67268,
     "name": "libtezos-ffi-ubuntu19.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/f7f24e14a628159dc5c773b81b03d8a6/libtezos-ffi-ubuntu19.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/f7f24e14a628159dc5c773b81b03d8a6/libtezos-ffi-ubuntu19.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/d81bba36de5f4a773bb60b97139b9311/libtezos-ffi-ubuntu19.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/d81bba36de5f4a773bb60b97139b9311/libtezos-ffi-ubuntu19.so",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67041,
+  },
+  {
+    "id": 67267,
     "name": "libtezos-ffi-ubuntu18.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/7f41c67866b6aa7cf7d26209337a94ae/libtezos-ffi-ubuntu18.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/7f41c67866b6aa7cf7d26209337a94ae/libtezos-ffi-ubuntu18.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/2de9c101b57b3cdb53770d94c219ea2b/libtezos-ffi-ubuntu18.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/2de9c101b57b3cdb53770d94c219ea2b/libtezos-ffi-ubuntu18.so.sha256",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67040,
+  },
+  {
+    "id": 67266,
     "name": "libtezos-ffi-ubuntu18.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/bd0ed0e614795ff766fb99d6dd7ac1ed/libtezos-ffi-ubuntu18.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/bd0ed0e614795ff766fb99d6dd7ac1ed/libtezos-ffi-ubuntu18.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/846708e869ec347ab1f891c1e84c43c6/libtezos-ffi-ubuntu18.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/846708e869ec347ab1f891c1e84c43c6/libtezos-ffi-ubuntu18.so",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67039,
+  },
+  {
+    "id": 67265,
     "name": "libtezos-ffi-ubuntu16.so.sha256",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/b38844650d2af2d29d059cf3bb43fd27/libtezos-ffi-ubuntu16.so.sha256",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/b38844650d2af2d29d059cf3bb43fd27/libtezos-ffi-ubuntu16.so.sha256",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/a59110c35e3849873c164cbf0ae1c918/libtezos-ffi-ubuntu16.so.sha256",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/a59110c35e3849873c164cbf0ae1c918/libtezos-ffi-ubuntu16.so.sha256",
     "external": false,
     "link_type": "other"
-}, {
-    "id": 67038,
+  },
+  {
+    "id": 67264,
     "name": "libtezos-ffi-ubuntu16.so",
-    "url": "https://gitlab.com/simplestaking/tezos/uploads/9f99acc7de5839756bc0663fde05e465/libtezos-ffi-ubuntu16.so",
-    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/9f99acc7de5839756bc0663fde05e465/libtezos-ffi-ubuntu16.so",
+    "url": "https://gitlab.com/simplestaking/tezos/uploads/4ed245635eaf2d31c3351094e2ac599a/libtezos-ffi-ubuntu16.so",
+    "direct_asset_url": "https://gitlab.com/simplestaking/tezos/uploads/4ed245635eaf2d31c3351094e2ac599a/libtezos-ffi-ubuntu16.so",
     "external": false,
     "link_type": "other"
-}]
+  }
+]

--- a/tezos/interop/src/ffi.rs
+++ b/tezos/interop/src/ffi.rs
@@ -1,7 +1,12 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use ocaml::{List, Str, ToValue, Tuple, Value};
+use std::sync::Once;
+
+use znfe::{
+    ocaml_alloc, ocaml_call, ocaml_frame, IntoRust, OCaml, OCamlBytes, OCamlFn1, OCamlInt32,
+    OCamlList, ToOCaml,
+};
 
 use tezos_api::ffi::*;
 use tezos_api::identity::Identity;
@@ -9,92 +14,121 @@ use tezos_api::identity::Identity;
 use crate::runtime;
 use crate::runtime::OcamlError;
 
-pub type OcamlBytes = Str;
-pub type OcamlHash = OcamlBytes;
+mod tezos_ffi {
+    use znfe::{ocaml, Intnat, OCamlBytes, OCamlInt32, OCamlList};
 
-pub trait Interchange<T> {
-    fn convert_to(&self) -> T;
-    fn is_empty(&self) -> bool;
+    ocaml! {
+        pub fn apply_block(apply_block_request: OCamlBytes) -> OCamlBytes;
+        pub fn begin_construction(begin_construction_request: OCamlBytes) -> OCamlBytes;
+        pub fn validate_operation(validate_operation_request: OCamlBytes) -> OCamlBytes;
+        pub fn call_protocol_json_rpc(request: OCamlBytes) -> OCamlBytes;
+        pub fn helpers_preapply_operations(request: OCamlBytes) -> OCamlBytes;
+        pub fn helpers_preapply_block(request: OCamlBytes) -> OCamlBytes;
+        pub fn change_runtime_configuration(
+            log_enabled: bool,
+            no_of_ffi_calls_treshold_for_gc: Intnat,
+            debug_mode: bool
+        ) -> ();
+        pub fn generate_identity(expected_pow: f64) -> OCamlBytes;
+        pub fn init_protocol_context(
+            data_dir: String,
+            genesis: (OCamlBytes, OCamlBytes, OCamlBytes),
+            protocol_override: (OCamlList<(OCamlInt32, OCamlBytes)>,
+                                OCamlList<(OCamlBytes, OCamlBytes)>),
+            configuration: (bool, bool, bool),
+            sandbox_json_patch_context: Option<(OCamlBytes, OCamlBytes)>
+        ) -> (OCamlList<OCamlBytes>, Option<OCamlBytes>);
+        pub fn genesis_result_data(
+            context_hash: OCamlBytes,
+            chain_id: OCamlBytes,
+            protocol_hash: OCamlBytes,
+            genesis_max_operations_ttl: Intnat
+        ) -> (OCamlBytes, OCamlBytes, OCamlBytes);
+        pub fn decode_context_data(
+            protocol_hash: OCamlBytes,
+            key: OCamlList<OCamlBytes>,
+            data: OCamlBytes
+        ) -> Option<OCamlBytes>;
+        pub fn compute_path(request: OCamlBytes) -> OCamlBytes;
+    }
 }
 
-fn copy_to_ocaml(bytes: &[u8]) -> Str {
-    let mut arr = Str::new(bytes.len());
-    let data = arr.data_mut();
-    for (n, i) in bytes.iter().enumerate() {
-        data[n] = *i;
-    }
-    arr
+/// Initializes the ocaml runtime and the tezos-ffi callback mechanism.
+pub fn setup() {
+    static INIT: Once = Once::new();
+
+    INIT.call_once(|| {
+        znfe::OCamlRuntime::init_persistent();
+        tezos_interop_callback::initialize_callbacks();
+    });
 }
 
-impl Interchange<OcamlBytes> for RustBytes {
-    fn convert_to(&self) -> OcamlBytes {
-        copy_to_ocaml(self.as_slice())
-    }
-
-    fn is_empty(&self) -> bool {
-        self.is_empty()
-    }
+/// Tries to shutdown ocaml runtime gracefully - give chance to close resources, trigger GC finalization...
+///
+/// https://caml.inria.fr/pub/docs/manual-ocaml/intfc.html#sec467
+pub fn shutdown() {
+    znfe::OCamlRuntime::shutdown_persistent()
 }
 
-impl Interchange<RustBytes> for OcamlBytes {
-    fn convert_to(&self) -> RustBytes {
-        self.data().to_vec()
-    }
-
-    fn is_empty(&self) -> bool {
-        self.is_empty()
-    }
-}
+type CallRequestFn = OCamlFn1<OCamlBytes, OCamlBytes>;
 
 /// Calls ffi function like request/response
-pub fn call<REQUEST, RESPONSE>(ffi_fn_name: String, request: REQUEST)
-                               -> Result<Result<RESPONSE, CallError>, OcamlError>
-    where
-        REQUEST: FfiMessage + 'static,
-        RESPONSE: FfiMessage + 'static {
+pub fn call<REQUEST, RESPONSE>(
+    ocaml_function: CallRequestFn,
+    request: REQUEST,
+) -> Result<Result<RESPONSE, CallError>, OcamlError>
+where
+    REQUEST: FfiMessage + 'static,
+    RESPONSE: FfiMessage + 'static,
+{
     runtime::execute(move || {
-        let ocaml_function = ocaml::named_value(&ffi_fn_name).expect(&format!("function '{}' is not registered", &ffi_fn_name));
-
         // write to bytes
         let request = match request.as_rust_bytes() {
             Ok(data) => data,
-            Err(e) => return Err(CallError::InvalidRequestData { message: format!("{:?}", e) })
+            Err(e) => {
+                return Err(CallError::InvalidRequestData {
+                    message: format!("{:?}", e),
+                })
+            }
         };
 
         // call ffi
-        match ocaml_function.call_exn::<OcamlBytes>(request.convert_to()) {
-            Ok(response) => {
-                let response: OcamlBytes = response.into();
-                let response: RustBytes = response.convert_to();
+        ocaml_frame!(gc, {
+            let request = ocaml_alloc!(request.to_ocaml(gc));
+            let result = ocaml_call!(ocaml_function(gc, request));
+            match result {
+                Ok(response) => {
+                    let response = response.into_rust();
 
-                let response = RESPONSE::from_rust_bytes(response)
-                    .map_err(|error| CallError::InvalidResponseData {
-                        message: format!("{}", error)
+                    let response = RESPONSE::from_rust_bytes(response).map_err(|error| {
+                        CallError::InvalidResponseData {
+                            message: format!("{}", error),
+                        }
                     })?;
-                Ok(response)
+                    Ok(response)
+                }
+                Err(e) => Err(CallError::from(e)),
             }
-            Err(e) => {
-                Err(CallError::from(e))
-            }
-        }
+        })
     })
 }
 
-pub fn change_runtime_configuration(settings: TezosRuntimeConfiguration) -> Result<Result<(), TezosRuntimeConfigurationError>, OcamlError> {
+pub fn change_runtime_configuration(
+    settings: TezosRuntimeConfiguration,
+) -> Result<Result<(), TezosRuntimeConfigurationError>, OcamlError> {
     runtime::execute(move || {
-        let ocaml_function = ocaml::named_value("change_runtime_configuration").expect("function 'change_runtime_configuration' is not registered");
-        match ocaml_function.call3_exn::<Value, Value, Value>(
-            Value::bool(settings.log_enabled),
-            Value::i32(settings.no_of_ffi_calls_treshold_for_gc),
-            Value::bool(settings.debug_mode),
-        ) {
-            Ok(_) => {
-                Ok(())
+        ocaml_frame!(gc, {
+            let result = ocaml_call!(tezos_ffi::change_runtime_configuration(
+                gc,
+                OCaml::of_bool(settings.log_enabled),
+                OCaml::of_int(settings.no_of_ffi_calls_treshold_for_gc as i64),
+                OCaml::of_bool(settings.debug_mode)
+            ));
+            match result {
+                Ok(_) => Ok(()),
+                Err(e) => Err(TezosRuntimeConfigurationError::from(e)),
             }
-            Err(e) => {
-                Err(TezosRuntimeConfigurationError::from(e))
-            }
-        }
+        })
     })
 }
 
@@ -108,231 +142,201 @@ pub fn init_protocol_context(
     patch_context: Option<PatchContext>,
 ) -> Result<Result<InitProtocolContextResult, TezosStorageInitError>, OcamlError> {
     runtime::execute(move || {
-        // genesis configuration
-        let mut genesis_tuple: Tuple = Tuple::new(3);
-        genesis_tuple.set(0, Str::from(genesis.time.as_str()).into()).unwrap();
-        genesis_tuple.set(1, Str::from(genesis.block.as_str()).into()).unwrap();
-        genesis_tuple.set(2, Str::from(genesis.protocol.as_str()).into()).unwrap();
+        ocaml_frame!(gc, {
+            // genesis configuration
+            let genesis_tuple = (genesis.time, genesis.block, genesis.protocol);
+            let genesis_tuple = ocaml_alloc!(genesis_tuple.to_ocaml(gc));
+            let ref genesis_tuple_ref = gc.keep(genesis_tuple);
 
-        // protocol overrides
-        let protocol_overrides_tuple: Tuple = protocol_overrides_to_ocaml(protocol_overrides)?;
+            // protocol overrides
+            let protocol_overrides_tuple = (
+                protocol_overrides.forced_protocol_upgrades,
+                protocol_overrides.voted_protocol_overrides,
+            );
+            let protocol_overrides_tuple: OCaml<(
+                OCamlList<(OCamlInt32, OCamlBytes)>,
+                OCamlList<(OCamlBytes, OCamlBytes)>,
+            )> = ocaml_alloc!(protocol_overrides_tuple.to_ocaml(gc));
+            let ref protocol_overrides_tuple_ref = gc.keep(protocol_overrides_tuple);
 
-        // configuration
-        let mut configuration: Tuple = Tuple::new(3);
-        configuration.set(0, Value::bool(commit_genesis)).unwrap();
-        configuration.set(1, Value::bool(enable_testchain)).unwrap();
-        configuration.set(2, Value::bool(readonly)).unwrap();
+            // configuration
+            let configuration = (commit_genesis, enable_testchain, readonly);
+            let configuration = ocaml_alloc!(configuration.to_ocaml(gc));
+            let ref configuration_ref = gc.keep(configuration);
 
-        // patch context
-        let patch_context = match patch_context {
-            Some(pc) => {
-                let mut patch_context: Tuple = Tuple::new(2);
-                patch_context.set(0, Str::from(pc.key.as_str()).into()).unwrap();
-                patch_context.set(1, Str::from(pc.json.as_str()).into()).unwrap();
-                Value::some(Value::from(patch_context))
-            }
-            None => Value::none()
-        };
+            // patch context
+            let patch_context_tuple = patch_context.map(|pc| (pc.key, pc.json));
+            let patch_context_tuple = ocaml_alloc!(patch_context_tuple.to_ocaml(gc));
+            let ref patch_context_tuple_ref = gc.keep(patch_context_tuple);
 
-        let ocaml_function = ocaml::named_value("init_protocol_context").expect("function 'init_protocol_context' is not registered");
-        match ocaml_function.call_n_exn(
-            [
-                Value::from(Str::from(storage_data_dir.as_str())),
-                Value::from(genesis_tuple),
-                Value::from(protocol_overrides_tuple),
-                Value::from(configuration),
-                patch_context,
-            ]
-        ) {
-            Ok(result) => {
-                let ocaml_result: Tuple = result.into();
+            let storage_data_dir = ocaml_alloc!(storage_data_dir.to_ocaml(gc));
+            let result = ocaml_call!(tezos_ffi::init_protocol_context(
+                gc,
+                storage_data_dir,
+                gc.get(genesis_tuple_ref),
+                gc.get(protocol_overrides_tuple_ref),
+                gc.get(configuration_ref),
+                gc.get(patch_context_tuple_ref)
+            ));
 
-                // 1. list known protocols
-                let supported_protocol_hashes: List = ocaml_result.get(0).unwrap().into();
-                let supported_protocol_hashes: Vec<RustBytes> = supported_protocol_hashes.to_vec()
-                    .iter()
-                    .map(|protocol_hash| {
-                        let protocol_hash: OcamlBytes = protocol_hash.clone().into();
-                        protocol_hash.convert_to()
+            match result {
+                Ok(result) => {
+                    let (supported_protocol_hashes, genesis_commit_hash): (
+                        Vec<RustBytes>,
+                        Option<RustBytes>,
+                    ) = result.into_rust();
+
+                    Ok(InitProtocolContextResult {
+                        supported_protocol_hashes,
+                        genesis_commit_hash,
                     })
-                    .collect();
-
-                // 2. context_hash option
-                let genesis_commit_context_hash: OcamlHash = ocaml_result.get(1).unwrap().into();
-                let genesis_commit_hash = if genesis_commit_context_hash.is_empty() {
-                    None
-                } else {
-                    Some(genesis_commit_context_hash.convert_to())
-                };
-
-                Ok(InitProtocolContextResult {
-                    supported_protocol_hashes,
-                    genesis_commit_hash,
-                })
+                }
+                Err(e) => Err(TezosStorageInitError::from(e)),
             }
-            Err(e) => {
-                Err(TezosStorageInitError::from(e))
-            }
-        }
+        })
     })
 }
 
-pub fn genesis_result_data(context_hash: RustBytes, chain_id: RustBytes, protocol_hash: RustBytes, genesis_max_operations_ttl: u16) -> Result<Result<CommitGenesisResult, GetDataError>, OcamlError> {
+pub fn genesis_result_data(
+    context_hash: RustBytes,
+    chain_id: RustBytes,
+    protocol_hash: RustBytes,
+    genesis_max_operations_ttl: u16,
+) -> Result<Result<CommitGenesisResult, GetDataError>, OcamlError> {
     runtime::execute(move || {
-        let context_hash: OcamlHash = context_hash.convert_to();
-        let chain_id: OcamlHash = chain_id.convert_to();
-        let protocol_hash: OcamlHash = protocol_hash.convert_to();
+        ocaml_frame!(gc, {
+            let context_hash = ocaml_alloc!(context_hash.to_ocaml(gc));
+            let ref context_hash_ref = gc.keep(context_hash);
+            let chain_id = ocaml_alloc!(chain_id.to_ocaml(gc));
+            let ref chain_id_ref = gc.keep(chain_id);
+            let protocol_hash = ocaml_alloc!(protocol_hash.to_ocaml(gc));
+            let genesis_max_operations_ttl = OCaml::of_int(genesis_max_operations_ttl as i64);
 
-        let ocaml_function = ocaml::named_value("genesis_result_data").expect("function 'genesis_result_data' is not registered");
-        match ocaml_function.call_n_exn(
-            vec![
-                context_hash.to_value(),
-                chain_id.to_value(),
-                protocol_hash.to_value(),
-                Value::usize(genesis_max_operations_ttl as usize),
-            ]
-        ) {
-            Ok(result) => {
-                let ocaml_result: Tuple = result.into();
-
-                // context_hash option
-                let block_header_proto_json: Str = ocaml_result.get(0).unwrap().into();
-                let block_header_proto_metadata_json: Str = ocaml_result.get(1).unwrap().into();
-                let operations_proto_metadata_json: Str = ocaml_result.get(2).unwrap().into();
-                Ok(
-                    CommitGenesisResult {
-                        block_header_proto_json: String::from(block_header_proto_json.as_str()),
-                        block_header_proto_metadata_json: String::from(block_header_proto_metadata_json.as_str()),
-                        operations_proto_metadata_json: String::from(operations_proto_metadata_json.as_str()),
-                    }
-                )
+            let result = ocaml_call!(tezos_ffi::genesis_result_data(
+                gc,
+                gc.get(context_hash_ref),
+                gc.get(chain_id_ref),
+                protocol_hash,
+                genesis_max_operations_ttl
+            ));
+            match result {
+                Ok(result) => {
+                    let (
+                        block_header_proto_json,
+                        block_header_proto_metadata_json,
+                        operations_proto_metadata_json,
+                    ) = result.into_rust();
+                    Ok(CommitGenesisResult {
+                        block_header_proto_json,
+                        block_header_proto_metadata_json,
+                        operations_proto_metadata_json,
+                    })
+                }
+                Err(e) => Err(GetDataError::from(e)),
             }
-            Err(e) => {
-                Err(GetDataError::from(e))
-            }
-        }
+        })
     })
 }
 
 /// Applies block to context
-pub fn apply_block(apply_block_request: ApplyBlockRequest) -> Result<Result<ApplyBlockResponse, CallError>, OcamlError> {
-    call(String::from("apply_block"), apply_block_request)
+pub fn apply_block(
+    apply_block_request: ApplyBlockRequest,
+) -> Result<Result<ApplyBlockResponse, CallError>, OcamlError> {
+    call(tezos_ffi::apply_block, apply_block_request)
 }
 
 /// Begin construction initializes prevalidator and context for new operations based on current head
-pub fn begin_construction(request: BeginConstructionRequest) -> Result<Result<PrevalidatorWrapper, CallError>, OcamlError> {
-    call(String::from("begin_construction"), request)
+pub fn begin_construction(
+    request: BeginConstructionRequest,
+) -> Result<Result<PrevalidatorWrapper, CallError>, OcamlError> {
+    call(tezos_ffi::begin_construction, request)
 }
 
 /// Validate operation - used with prevalidator for validation of operation
-pub fn validate_operation(request: ValidateOperationRequest) -> Result<Result<ValidateOperationResponse, CallError>, OcamlError> {
-    call(String::from("validate_operation"), request)
+pub fn validate_operation(
+    request: ValidateOperationRequest,
+) -> Result<Result<ValidateOperationResponse, CallError>, OcamlError> {
+    call(tezos_ffi::validate_operation, request)
 }
 
 /// Call protocol json rpc - general service
-pub fn call_protocol_json_rpc(request: ProtocolJsonRpcRequest) -> Result<Result<JsonRpcResponse, CallError>, OcamlError> {
-    call(String::from("call_protocol_json_rpc"), request)
+pub fn call_protocol_json_rpc(
+    request: ProtocolJsonRpcRequest,
+) -> Result<Result<JsonRpcResponse, CallError>, OcamlError> {
+    call(tezos_ffi::call_protocol_json_rpc, request)
 }
 
 /// Call helpers_preapply_operations shell service
-pub fn helpers_preapply_operations(request: ProtocolJsonRpcRequest) -> Result<Result<JsonRpcResponse, CallError>, OcamlError> {
-    call(String::from("helpers_preapply_operations"), request)
+pub fn helpers_preapply_operations(
+    request: ProtocolJsonRpcRequest,
+) -> Result<Result<JsonRpcResponse, CallError>, OcamlError> {
+    call(tezos_ffi::helpers_preapply_operations, request)
 }
 
 /// Call helpers_preapply_block shell service
-pub fn helpers_preapply_block(request: ProtocolJsonRpcRequest) -> Result<Result<JsonRpcResponse, CallError>, OcamlError> {
-    call(String::from("helpers_preapply_block"), request)
+pub fn helpers_preapply_block(
+    request: ProtocolJsonRpcRequest,
+) -> Result<Result<JsonRpcResponse, CallError>, OcamlError> {
+    call(tezos_ffi::helpers_preapply_block, request)
 }
 
 /// Call compute path
-pub fn compute_path(request: ComputePathRequest) -> Result<Result<ComputePathResponse, CallError>, OcamlError> {
-    call(String::from("compute_path"), request)
+pub fn compute_path(
+    request: ComputePathRequest,
+) -> Result<Result<ComputePathResponse, CallError>, OcamlError> {
+    call(tezos_ffi::compute_path, request)
 }
 
-pub fn generate_identity(expected_pow: f64) -> Result<Result<Identity, TezosGenerateIdentityError>, OcamlError> {
+pub fn generate_identity(
+    expected_pow: f64,
+) -> Result<Result<Identity, TezosGenerateIdentityError>, OcamlError> {
     runtime::execute(move || {
-        let ocaml_function = ocaml::named_value("generate_identity").expect("function 'generate_identity' is not registered");
-        match ocaml_function.call_exn::<Value>(Value::f64(expected_pow)) {
-            Ok(identity) => {
-                let identity = Str::from(identity).as_str().to_string();
+        ocaml_frame!(gc, {
+            let expected_pow = ocaml_alloc!(expected_pow.to_ocaml(gc));
+            let result = ocaml_call!(tezos_ffi::generate_identity(gc, expected_pow));
+            match result {
+                Ok(identity) => {
+                    let identity: String = identity.into_rust();
 
-                Ok(serde_json::from_str::<Identity>(&identity)
-                    .map_err(|err| TezosGenerateIdentityError::InvalidJsonError { message: err.to_string() })?
-                )
-            }
-            Err(e) => {
-                Err(TezosGenerateIdentityError::from(e))
-            }
-        }
-    })
-}
-
-pub fn decode_context_data(protocol_hash: RustBytes, key: Vec<String>, data: RustBytes) -> Result<Result<Option<String>, ContextDataError>, OcamlError> {
-    runtime::execute(move || {
-        let mut key_list = List::new();
-        key.iter()
-            .rev()
-            .for_each(|k| key_list.push_hd(Str::from(k.as_str()).into()));
-
-        let ocaml_function = ocaml::named_value("decode_context_data").expect("function 'decode_context_data' is not registered");
-        match ocaml_function.call3_exn::<OcamlHash, List, OcamlBytes>(protocol_hash.convert_to(), key_list, data.convert_to()) {
-            Ok(decoded_data) => {
-                let decoded_data: Str = decoded_data.into();
-                if decoded_data.is_empty() {
-                    Ok(None)
-                } else {
-                    Ok(Some(decoded_data.as_str().to_string()))
+                    Ok(serde_json::from_str::<Identity>(&identity).map_err(|err| {
+                        TezosGenerateIdentityError::InvalidJsonError {
+                            message: err.to_string(),
+                        }
+                    })?)
                 }
+                Err(e) => Err(TezosGenerateIdentityError::from(e)),
             }
-            Err(e) => {
-                Err(ContextDataError::from(e))
-            }
-        }
+        })
     })
 }
 
-pub fn operations_to_ocaml(operations: &Vec<Option<Vec<RustBytes>>>) -> List {
-    let mut operations_for_ocaml = List::new();
+pub fn decode_context_data(
+    protocol_hash: RustBytes,
+    key: Vec<String>,
+    data: RustBytes,
+) -> Result<Result<Option<String>, ContextDataError>, OcamlError> {
+    runtime::execute(move || {
+        ocaml_frame!(gc, {
+            let protocol_hash = ocaml_alloc!(protocol_hash.to_ocaml(gc));
+            let ref protocol_hash_ref = gc.keep(protocol_hash);
+            let key_list: OCaml<OCamlList<OCamlBytes>> = ocaml_alloc!(key.to_ocaml(gc));
+            let ref key_list_ref = gc.keep(key_list);
+            let data = ocaml_alloc!(data.to_ocaml(gc));
 
-    operations.into_iter().rev()
-        .for_each(|ops_option| {
-            let ops_array = if let Some(ops) = ops_option {
-                let mut ops_array = List::new();
-                ops.into_iter().rev().for_each(|op| {
-                    let op: OcamlBytes = op.convert_to();
-                    ops_array.push_hd(Value::from(op));
-                });
-                ops_array
-            } else {
-                List::new()
-            };
-            operations_for_ocaml.push_hd(Value::from(ops_array));
-        });
+            let result = ocaml_call!(tezos_ffi::decode_context_data(
+                gc,
+                gc.get(protocol_hash_ref),
+                gc.get(key_list_ref),
+                data
+            ));
 
-    operations_for_ocaml
-}
-
-pub fn protocol_overrides_to_ocaml(protocol_overrides: ProtocolOverrides) -> Result<Tuple, ocaml::Error> {
-    let mut forced_protocol_upgrades = List::new();
-    protocol_overrides.forced_protocol_upgrades.iter().rev()
-        .for_each(|(level, protocol_hash)| {
-            let mut tuple: Tuple = Tuple::new(2);
-            tuple.set(0, Value::int32(level.clone())).unwrap();
-            tuple.set(1, Str::from(protocol_hash.as_str()).into()).unwrap();
-            forced_protocol_upgrades.push_hd(Value::from(tuple));
-        });
-
-    let mut voted_protocol_overrides = List::new();
-    protocol_overrides.voted_protocol_overrides.iter().rev()
-        .for_each(|(protocol_hash1, protocol_hash2)| {
-            let mut tuple: Tuple = Tuple::new(2);
-            tuple.set(0, Str::from(protocol_hash1.as_str()).into()).unwrap();
-            tuple.set(1, Str::from(protocol_hash2.as_str()).into()).unwrap();
-            voted_protocol_overrides.push_hd(Value::from(tuple));
-        });
-
-    let mut protocol_overrides: Tuple = Tuple::new(2);
-    protocol_overrides.set(0, Value::from(forced_protocol_upgrades))?;
-    protocol_overrides.set(1, Value::from(voted_protocol_overrides))?;
-    Ok(protocol_overrides)
+            match result {
+                Ok(decoded_data) => {
+                    let decoded_data = decoded_data.into_rust();
+                    Ok(decoded_data)
+                }
+                Err(e) => Err(ContextDataError::from(e)),
+            }
+        })
+    })
 }

--- a/tezos/interop/src/lib.rs
+++ b/tezos/interop/src/lib.rs
@@ -14,13 +14,19 @@
 /// ```rust, no_run
 /// use tezos_interop::runtime::OcamlResult;
 /// use tezos_interop::runtime;
-/// use ocaml::{Str};
+/// use znfe::{ocaml, ocaml_frame, ocaml_alloc, ocaml_call, ToOCaml, FromOCaml};
+///
+/// ocaml! {
+///     pub fn echo(value: String) -> String;
+/// }
 ///
 /// fn ocaml_fn_echo(arg: String) -> OcamlResult<String> {
 ///     runtime::spawn(move || {
-///         let ocaml_function = ocaml::named_value("echo").expect("function 'echo' is not registered");
-///         let ocaml_result: Str = ocaml_function.call::<Str>(arg.as_str().into()).unwrap().into();
-///         ocaml_result.as_str().to_string()
+///         ocaml_frame!(gc, {
+///             let value = ocaml_alloc!(arg.to_ocaml(gc));
+///             let ocaml_result = ocaml_call!(echo(gc, value));
+///             String::from_ocaml(ocaml_result.unwrap())
+///         })
 ///     })
 /// }
 ///

--- a/tezos/interop/tests/runtime_call_ocaml_tests.rs
+++ b/tezos/interop/tests/runtime_call_ocaml_tests.rs
@@ -8,15 +8,6 @@ fn can_complete_future_with_return_value() -> Result<(), OcamlError> {
 }
 
 #[test]
-fn can_complete_future_with_unregistered_function() {
-    let res = runtime::execute(|| {
-        let _ = ocaml::named_value("__non_existing_fn")
-            .expect("function '__non_existing_fn' is not registered");
-    });
-    assert!(res.is_err())
-}
-
-#[test]
 fn can_complete_future_with_error() {
     let res = runtime::execute(|| {
         panic!("Error occurred");

--- a/tezos/interop_callback/Cargo.toml
+++ b/tezos/interop_callback/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 crate-type = ["dylib", "rlib"]
 
 [dependencies]
-ocaml = "0.9.3"
+znfe = { git = "https://github.com/tizoc/znfe.git", tag="v0.1.0" }
 # local dependencies
 tezos_context = { path = "../context" }

--- a/tezos/interop_callback/src/callback.rs
+++ b/tezos/interop_callback/src/callback.rs
@@ -3,12 +3,10 @@
 
 //! This module provides all the FFI callback functions.
 
-use ocaml::{caml, List, Str, Tuple, Value};
-use ocaml::value::TRUE;
+use znfe::{ocaml_export, IntoRust, OCaml, OCamlList, RawOCaml};
 
 use tezos_context::channel::*;
 
-type OcamlBytes = Str;
 type Hash = Vec<u8>;
 type ContextHash = Hash;
 type BlockHash = Hash;
@@ -16,209 +14,211 @@ type OperationHash = Hash;
 type ContextKey = Vec<String>;
 type ContextValue = Vec<u8>;
 
-pub trait Interchange<T> {
-    fn convert_to(&self) -> T;
+extern "C" {
+    fn initialize_ml_context_functions(
+        ml_context_set: unsafe extern "C" fn(RawOCaml, RawOCaml, RawOCaml, RawOCaml, f64, f64) -> RawOCaml,
+        ml_context_delete: unsafe extern "C" fn(RawOCaml, RawOCaml, RawOCaml, RawOCaml, f64, f64) -> RawOCaml,
+        ml_context_remove_rec: unsafe extern "C" fn(RawOCaml, RawOCaml, RawOCaml, RawOCaml, f64, f64) -> RawOCaml,
+        ml_context_copy: unsafe extern "C" fn(RawOCaml, RawOCaml, RawOCaml, RawOCaml, f64, f64) -> RawOCaml,
+        ml_context_checkout: unsafe extern "C" fn(RawOCaml, f64, f64) -> RawOCaml,
+        ml_context_commit: unsafe extern "C" fn(RawOCaml, RawOCaml, RawOCaml, f64, f64) -> RawOCaml,
+        ml_context_mem: unsafe extern "C" fn(RawOCaml, RawOCaml, RawOCaml, RawOCaml, f64, f64) -> RawOCaml,
+        ml_context_dir_mem: unsafe extern "C" fn(RawOCaml, RawOCaml, RawOCaml, RawOCaml, f64, f64) -> RawOCaml,
+        ml_context_raw_get: unsafe extern "C" fn(RawOCaml, RawOCaml, RawOCaml, RawOCaml, f64, f64) -> RawOCaml,
+        ml_context_fold: unsafe extern "C" fn(RawOCaml, RawOCaml, RawOCaml, RawOCaml, f64, f64) -> RawOCaml,
+    );
 }
 
-impl Interchange<Vec<u8>> for OcamlBytes {
-    fn convert_to(&self) -> ContextHash {
-        self.data().to_vec()
+pub fn initialize_callbacks() {
+    unsafe {
+        initialize_ml_context_functions(
+            real_ml_context_set,
+            real_ml_context_delete,
+            real_ml_context_remove_rec,
+            real_ml_context_copy,
+            real_ml_context_checkout,
+            real_ml_context_commit,
+            real_ml_context_mem,
+            real_ml_context_dir_mem,
+            real_ml_context_raw_get,
+            real_ml_context_fold)
     }
 }
 
-impl Interchange<ContextKey> for List {
-    fn convert_to(&self) -> ContextKey {
-        self.to_vec()
-            .into_iter()
-            .map(|k| Str::from(k).as_str().to_string())
-            .collect()
+ocaml_export! {
+
+    // External callback function for set value to context
+    fn real_ml_context_set(gc,
+        context_hash: OCaml<Option<String>>,
+        block_hash: OCaml<Option<String>>,
+        operation_hash: OCaml<Option<String>>,
+        keyval_and_json: OCaml<(OCamlList<String>, String, Option<String>, bool)>,
+        start_time: f64,
+        end_time: f64,
+    ) {
+        let context_hash = context_hash.into_rust();
+        let block_hash = block_hash.into_rust();
+        let operation_hash = operation_hash.into_rust();
+        let (key, value, json_val, ignored) = keyval_and_json.into_rust();
+
+        context_set(context_hash, block_hash, operation_hash, key, value, json_val, ignored, start_time, end_time);
+        OCaml::unit()
+    }
+
+    // External callback function for delete key from context
+    fn real_ml_context_delete(gc,
+        context_hash: OCaml<Option<String>>,
+        block_hash: OCaml<Option<String>>,
+        operation_hash: OCaml<Option<String>>,
+        keyval: OCaml<(OCamlList<String>, bool)>,
+        start_time: f64,
+        end_time: f64,
+    ) {
+        let context_hash = context_hash.into_rust();
+        let block_hash = block_hash.into_rust();
+        let operation_hash = operation_hash.into_rust();
+        let (key, ignored) = keyval.into_rust();
+
+        context_delete(context_hash, block_hash, operation_hash, key, ignored, start_time, end_time);
+        OCaml::unit()
+    }
+
+    // External callback function for remove_rec key from context
+    fn real_ml_context_remove_rec(gc,
+        context_hash: OCaml<Option<String>>,
+        block_hash: OCaml<Option<String>>,
+        operation_hash: OCaml<Option<String>>,
+        keyval: OCaml<(OCamlList<String>, bool)>,
+        start_time: f64,
+        end_time: f64,
+    ) {
+        let context_hash = context_hash.into_rust();
+        let block_hash = block_hash.into_rust();
+        let operation_hash = operation_hash.into_rust();
+        let (key, ignored) = keyval.into_rust();
+
+        context_remove_rec(context_hash, block_hash, operation_hash, key, ignored, start_time, end_time);
+        OCaml::unit()
+    }
+
+    // External callback function for copy keys from context
+    fn real_ml_context_copy(gc,
+        context_hash: OCaml<Option<String>>,
+        block_hash: OCaml<Option<String>>,
+        operation_hash: OCaml<Option<String>>,
+        from_to_key: OCaml<(OCamlList<String>, OCamlList<String>, bool)>,
+        start_time: f64,
+        end_time: f64,
+    ) {
+        let context_hash = context_hash.into_rust();
+        let block_hash = block_hash.into_rust();
+        let operation_hash = operation_hash.into_rust();
+        let (from_key, to_key, ignored) = from_to_key.into_rust();
+
+        context_copy(context_hash, block_hash, operation_hash, from_key, to_key, ignored, start_time, end_time);
+        OCaml::unit()
+    }
+
+    // External callback function for checkout context
+    fn real_ml_context_checkout(gc,
+        context_hash: OCaml<String>,
+        start_time: f64,
+        end_time: f64,
+    ) {
+        let context_hash = context_hash.into_rust();
+
+        context_checkout(context_hash, start_time, end_time);
+        OCaml::unit()
+    }
+
+    // External callback function for checkout context
+    fn real_ml_context_commit(gc,
+        parent_context_hash: OCaml<Option<String>>,
+        block_hash: OCaml<Option<String>>,
+        new_context_hash: OCaml<String>,
+        start_time: f64,
+        end_time: f64,
+    ) {
+        let parent_context_hash = parent_context_hash.into_rust();
+        let block_hash = block_hash.into_rust();
+        let new_context_hash = new_context_hash.into_rust();
+
+        context_commit(parent_context_hash, block_hash, new_context_hash, start_time, end_time);
+        OCaml::unit()
+    }
+
+    // External callback function for mem key from context
+    fn real_ml_context_mem(gc,
+        context_hash: OCaml<Option<String>>,
+        block_hash: OCaml<Option<String>>,
+        operation_hash: OCaml<Option<String>>,
+        keyval: OCaml<(OCamlList<String>, bool)>,
+        start_time: f64,
+        end_time: f64,
+    ) {
+        let context_hash = context_hash.into_rust();
+        let block_hash = block_hash.into_rust();
+        let operation_hash = operation_hash.into_rust();
+        let (key, value) = keyval.into_rust();
+
+        context_mem(context_hash, block_hash, operation_hash, key, value, start_time, end_time);
+        OCaml::unit()
+    }
+
+    // External callback function for dir_mem key from context
+    fn real_ml_context_dir_mem(gc,
+        context_hash: OCaml<Option<String>>,
+        block_hash: OCaml<Option<String>>,
+        operation_hash: OCaml<Option<String>>,
+        keyval: OCaml<(OCamlList<String>, bool)>,
+        start_time: f64,
+        end_time: f64,
+    ) {
+        let context_hash = context_hash.into_rust();
+        let block_hash = block_hash.into_rust();
+        let operation_hash = operation_hash.into_rust();
+        let (key, value) = keyval.into_rust();
+
+        context_dir_mem(context_hash, block_hash, operation_hash, key, value, start_time, end_time);
+        OCaml::unit()
+    }
+
+    // External callback function for raw_get key from context
+    fn real_ml_context_raw_get(gc,
+        context_hash: OCaml<Option<String>>,
+        block_hash: OCaml<Option<String>>,
+        operation_hash: OCaml<Option<String>>,
+        keyval_and_json: OCaml<(OCamlList<String>, String, Option<String>)>,
+        start_time: f64,
+        end_time: f64,
+    ) {
+        let context_hash = context_hash.into_rust();
+        let block_hash = block_hash.into_rust();
+        let operation_hash = operation_hash.into_rust();
+        let (key, value, json_val) =  keyval_and_json.into_rust();
+
+        context_raw_get(context_hash, block_hash, operation_hash, key, value, json_val, start_time, end_time);
+        OCaml::unit()
+    }
+
+    // External callback function for fold key from context
+    fn real_ml_context_fold(gc,
+        context_hash: OCaml<Option<String>>,
+        block_hash: OCaml<Option<String>>,
+        operation_hash: OCaml<Option<String>>,
+        key: OCaml<OCamlList<String>>,
+        start_time: f64,
+        end_time: f64,
+    ) {
+        let context_hash = context_hash.into_rust();
+        let block_hash = block_hash.into_rust();
+        let operation_hash = operation_hash.into_rust();
+        let key = key.into_rust();
+
+        context_fold(context_hash, block_hash, operation_hash, key, start_time, end_time);
+        OCaml::unit()
     }
 }
-
-fn to_hash(hash: Str) -> Option<Hash> {
-    if hash.is_empty() {
-        None
-    } else {
-        Some(hash.data().to_vec())
-    }
-}
-
-fn to_string(value: Str) -> Option<String> {
-    if value.is_empty() {
-        None
-    } else {
-        Some(value.as_str().to_string())
-    }
-}
-
-// External callback function for set value to context
-caml!(ml_context_set(context_hash, block_hash, operation_hash, keyval_and_json, time_period) {
-    let context_hash: Option<ContextHash> = to_hash(context_hash.into());
-    let block_hash: Option<BlockHash> = to_hash(block_hash.into());
-    let operation_hash: Option<OperationHash> = to_hash(operation_hash.into());
-
-    let keyval_and_json: Tuple = keyval_and_json.into();
-    let key: ContextKey = List::from(keyval_and_json.get(0).unwrap()).convert_to();
-    let value: ContextValue = OcamlBytes::from(keyval_and_json.get(1).unwrap()).convert_to();
-    let json_val: Option<String> = to_string(keyval_and_json.get(2).unwrap().into());
-    let ignored: bool = keyval_and_json.get(3).unwrap().i32_val() == TRUE.i32_val();
-
-    let time_period: Tuple = time_period.into();
-    let start_time: f64 = time_period.get(0).unwrap().f64_val();
-    let end_time: f64 = time_period.get(1).unwrap().f64_val();
-
-    context_set(context_hash, block_hash, operation_hash, key, value, json_val, ignored, start_time, end_time);
-    Value::unit()
-});
-
-// External callback function for delete key from context
-caml!(ml_context_delete(context_hash, block_hash, operation_hash, keyval, time_period) {
-    let context_hash: Option<ContextHash> = to_hash(context_hash.into());
-    let block_hash: Option<BlockHash> = to_hash(block_hash.into());
-    let operation_hash: Option<OperationHash> = to_hash(operation_hash.into());
-
-    let keyval: Tuple = keyval.into();
-    let key: ContextKey = List::from(keyval.get(0).unwrap()).convert_to();
-    let ignored: bool = keyval.get(1).unwrap().i32_val() == TRUE.i32_val();
-
-    let time_period: Tuple = time_period.into();
-    let start_time: f64 = time_period.get(0).unwrap().f64_val();
-    let end_time: f64 = time_period.get(1).unwrap().f64_val();
-
-    context_delete(context_hash, block_hash, operation_hash, key, ignored, start_time, end_time);
-    Value::unit()
-});
-
-// External callback function for remove_rec key from context
-caml!(ml_context_remove_rec(context_hash, block_hash, operation_hash, keyval, time_period) {
-    let context_hash: Option<ContextHash> = to_hash(context_hash.into());
-    let block_hash: Option<BlockHash> = to_hash(block_hash.into());
-    let operation_hash: Option<OperationHash> = to_hash(operation_hash.into());
-
-    let keyval: Tuple = keyval.into();
-    let key: ContextKey = List::from(keyval.get(0).unwrap()).convert_to();
-    let ignored: bool = keyval.get(1).unwrap().i32_val() == TRUE.i32_val();
-
-    let time_period: Tuple = time_period.into();
-    let start_time: f64 = time_period.get(0).unwrap().f64_val();
-    let end_time: f64 = time_period.get(1).unwrap().f64_val();
-
-    context_remove_rec(context_hash, block_hash, operation_hash, key, ignored, start_time, end_time);
-    Value::unit()
-});
-
-// External callback function for copy keys from context
-caml!(ml_context_copy(context_hash, block_hash, operation_hash, from_to_key, time_period) {
-    let context_hash: Option<ContextHash> = to_hash(context_hash.into());
-    let block_hash: Option<BlockHash> = to_hash(block_hash.into());
-    let operation_hash: Option<OperationHash> = to_hash(operation_hash.into());
-
-    let from_to_key: Tuple = from_to_key.into();
-    let from_key: ContextKey = List::from(from_to_key.get(0).unwrap()).convert_to();
-    let to_key: ContextKey = List::from(from_to_key.get(1).unwrap()).convert_to();
-    let ignored: bool = from_to_key.get(2).unwrap().i32_val() == TRUE.i32_val();
-
-    let time_period: Tuple = time_period.into();
-    let start_time: f64 = time_period.get(0).unwrap().f64_val();
-    let end_time: f64 = time_period.get(1).unwrap().f64_val();
-
-    context_copy(context_hash, block_hash, operation_hash, from_key, to_key, ignored, start_time, end_time);
-    Value::unit()
-});
-
-// External callback function for checkout context
-caml!(ml_context_checkout(context_hash, time_period) {
-    let context_hash: ContextHash = to_hash(context_hash.into()).unwrap();
-
-    let time_period: Tuple = time_period.into();
-    let start_time: f64 = time_period.get(0).unwrap().f64_val();
-    let end_time: f64 = time_period.get(1).unwrap().f64_val();
-
-    context_checkout(context_hash, start_time, end_time);
-    Value::unit()
-});
-
-// External callback function for checkout context
-caml!(ml_context_commit(parent_context_hash, block_hash, new_context_hash, time_period) {
-    let parent_context_hash: Option<ContextHash> = to_hash(parent_context_hash.into());
-    let block_hash: Option<BlockHash> = to_hash(block_hash.into());
-    let new_context_hash: ContextHash = to_hash(new_context_hash.into()).unwrap();
-
-    let time_period: Tuple = time_period.into();
-    let start_time: f64 = time_period.get(0).unwrap().f64_val();
-    let end_time: f64 = time_period.get(1).unwrap().f64_val();
-
-    context_commit(parent_context_hash, block_hash, new_context_hash, start_time, end_time);
-    Value::unit()
-});
-
-// External callback function for mem key from context
-caml!(ml_context_mem(context_hash, block_hash, operation_hash, keyval, time_period) {
-    let context_hash: Option<ContextHash> = to_hash(context_hash.into());
-    let block_hash: Option<BlockHash> = to_hash(block_hash.into());
-    let operation_hash: Option<OperationHash> = to_hash(operation_hash.into());
-    let keyval: Tuple = keyval.into();
-    let key: ContextKey = List::from(keyval.get(0).unwrap()).convert_to();
-    let value: bool = keyval.get(1).unwrap().i32_val() > 0;
-
-    let time_period: Tuple = time_period.into();
-    let start_time: f64 = time_period.get(0).unwrap().f64_val();
-    let end_time: f64 = time_period.get(1).unwrap().f64_val();
-
-    context_mem(context_hash, block_hash, operation_hash, key, value, start_time, end_time);
-    Value::unit()
-});
-
-// External callback function for dir_mem key from context
-caml!(ml_context_dir_mem(context_hash, block_hash, operation_hash, keyval, time_period) {
-    let context_hash: Option<ContextHash> = to_hash(context_hash.into());
-    let block_hash: Option<BlockHash> = to_hash(block_hash.into());
-    let operation_hash: Option<OperationHash> = to_hash(operation_hash.into());
-    let keyval: Tuple = keyval.into();
-    let key: ContextKey = List::from(keyval.get(0).unwrap()).convert_to();
-    let value: bool = keyval.get(1).unwrap().i32_val() > 0;
-
-    let time_period: Tuple = time_period.into();
-    let start_time: f64 = time_period.get(0).unwrap().f64_val();
-    let end_time: f64 = time_period.get(1).unwrap().f64_val();
-
-    context_dir_mem(context_hash, block_hash, operation_hash, key, value, start_time, end_time);
-    Value::unit()
-});
-
-// External callback function for raw_get key from context
-caml!(ml_context_raw_get(context_hash, block_hash, operation_hash, keyval_and_json, time_period) {
-    let context_hash: Option<ContextHash> = to_hash(context_hash.into());
-    let block_hash: Option<BlockHash> = to_hash(block_hash.into());
-    let operation_hash: Option<OperationHash> = to_hash(operation_hash.into());
-
-    let keyval_and_json: Tuple = keyval_and_json.into();
-    let key: ContextKey = List::from(keyval_and_json.get(0).unwrap()).convert_to();
-    let value: ContextValue = OcamlBytes::from(keyval_and_json.get(1).unwrap()).convert_to();
-    let json_val: Option<String> = to_string(keyval_and_json.get(2).unwrap().into());
-
-    let time_period: Tuple = time_period.into();
-    let start_time: f64 = time_period.get(0).unwrap().f64_val();
-    let end_time: f64 = time_period.get(1).unwrap().f64_val();
-
-    context_raw_get(context_hash, block_hash, operation_hash, key, value, json_val, start_time, end_time);
-    Value::unit()
-});
-
-// External callback function for fold key from context
-caml!(ml_context_fold(context_hash, block_hash, operation_hash, key, time_period) {
-    let context_hash: Option<ContextHash> = to_hash(context_hash.into());
-    let block_hash: Option<BlockHash> = to_hash(block_hash.into());
-    let operation_hash: Option<OperationHash> = to_hash(operation_hash.into());
-    let key: ContextKey = List::from(key).convert_to();
-
-    let time_period: Tuple = time_period.into();
-    let start_time: f64 = time_period.get(0).unwrap().f64_val();
-    let end_time: f64 = time_period.get(1).unwrap().f64_val();
-
-    context_fold(context_hash, block_hash, operation_hash, key, start_time, end_time);
-    Value::unit()
-});
 
 fn context_set(
     context_hash: Option<ContextHash>,
@@ -229,8 +229,8 @@ fn context_set(
     value_as_json: Option<String>,
     ignored: bool,
     start_time: f64,
-    end_time: f64)
-{
+    end_time: f64,
+) {
     context_send(ContextAction::Set {
         context_hash,
         block_hash,
@@ -241,7 +241,8 @@ fn context_set(
         ignored,
         start_time,
         end_time,
-    }).expect("context_set error");
+    })
+    .expect("context_set error");
 }
 
 fn context_delete(
@@ -251,8 +252,8 @@ fn context_delete(
     key: ContextKey,
     ignored: bool,
     start_time: f64,
-    end_time: f64)
-{
+    end_time: f64,
+) {
     context_send(ContextAction::Delete {
         context_hash,
         block_hash,
@@ -261,7 +262,8 @@ fn context_delete(
         ignored,
         start_time,
         end_time,
-    }).expect("context_delete error");
+    })
+    .expect("context_delete error");
 }
 
 fn context_remove_rec(
@@ -271,8 +273,8 @@ fn context_remove_rec(
     key: ContextKey,
     ignored: bool,
     start_time: f64,
-    end_time: f64)
-{
+    end_time: f64,
+) {
     context_send(ContextAction::RemoveRecursively {
         context_hash,
         block_hash,
@@ -281,7 +283,8 @@ fn context_remove_rec(
         ignored,
         start_time,
         end_time,
-    }).expect("context_remove_rec error");
+    })
+    .expect("context_remove_rec error");
 }
 
 fn context_copy(
@@ -292,8 +295,8 @@ fn context_copy(
     to_key: ContextKey,
     ignored: bool,
     start_time: f64,
-    end_time: f64)
-{
+    end_time: f64,
+) {
     context_send(ContextAction::Copy {
         context_hash,
         block_hash,
@@ -303,19 +306,17 @@ fn context_copy(
         ignored,
         start_time,
         end_time,
-    }).expect("context_copy error");
+    })
+    .expect("context_copy error");
 }
 
-fn context_checkout(
-    context_hash: ContextHash,
-    start_time: f64,
-    end_time: f64)
-{
+fn context_checkout(context_hash: ContextHash, start_time: f64, end_time: f64) {
     context_send(ContextAction::Checkout {
         context_hash,
         start_time,
         end_time,
-    }).expect("context_checkout error");
+    })
+    .expect("context_checkout error");
 }
 
 fn context_commit(
@@ -323,15 +324,16 @@ fn context_commit(
     block_hash: Option<BlockHash>,
     new_context_hash: ContextHash,
     start_time: f64,
-    end_time: f64)
-{
+    end_time: f64,
+) {
     context_send(ContextAction::Commit {
         parent_context_hash,
         block_hash,
         new_context_hash,
         start_time,
         end_time,
-    }).expect("context_commit error");
+    })
+    .expect("context_commit error");
 }
 
 fn context_mem(
@@ -341,8 +343,8 @@ fn context_mem(
     key: ContextKey,
     value: bool,
     start_time: f64,
-    end_time: f64)
-{
+    end_time: f64,
+) {
     context_send(ContextAction::Mem {
         context_hash,
         block_hash,
@@ -351,7 +353,8 @@ fn context_mem(
         value,
         start_time,
         end_time,
-    }).expect("context_mem error");
+    })
+    .expect("context_mem error");
 }
 
 fn context_dir_mem(
@@ -361,8 +364,8 @@ fn context_dir_mem(
     key: ContextKey,
     value: bool,
     start_time: f64,
-    end_time: f64)
-{
+    end_time: f64,
+) {
     context_send(ContextAction::DirMem {
         context_hash,
         block_hash,
@@ -371,7 +374,8 @@ fn context_dir_mem(
         value,
         start_time,
         end_time,
-    }).expect("context_dir_mem error");
+    })
+    .expect("context_dir_mem error");
 }
 
 fn context_raw_get(
@@ -382,8 +386,8 @@ fn context_raw_get(
     value: ContextValue,
     value_as_json: Option<String>,
     start_time: f64,
-    end_time: f64)
-{
+    end_time: f64,
+) {
     context_send(ContextAction::Get {
         context_hash,
         block_hash,
@@ -393,7 +397,8 @@ fn context_raw_get(
         value_as_json,
         start_time,
         end_time,
-    }).expect("context_get error");
+    })
+    .expect("context_get error");
 }
 
 fn context_fold(
@@ -402,8 +407,8 @@ fn context_fold(
     operation_hash: Option<OperationHash>,
     key: ContextKey,
     start_time: f64,
-    end_time: f64)
-{
+    end_time: f64,
+) {
     context_send(ContextAction::Fold {
         context_hash,
         block_hash,
@@ -411,5 +416,6 @@ fn context_fold(
         key,
         start_time,
         end_time,
-    }).expect("context_fold error");
+    })
+    .expect("context_fold error");
 }

--- a/tezos/interop_callback/src/lib.rs
+++ b/tezos/interop_callback/src/lib.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 //! This crate exposes Rust FFI interface which can be called from the OCaml.
-
 mod callback;
+
+pub use callback::initialize_callbacks;


### PR DESCRIPTION
Switch to new FFI.

- [x] `ocaml-rs` replaced with `znfe`.
- [x] fixes some instances where the OCaml GC rules where not being implemented correctly.
- [x] initialize `libtezos-ffi` by passing pointers to all `ml_context_*` functions to avoid cyclic dependency, this solves the cyclic linking issue on Linux, and the hangouts on OSX.
- [x] use `Option<hash>` instead of empty strings to represent null hashes and json values
- [x] fix bug in unboxed float conversion
- [x] use unboxed floats to receive time periods
- [x] use tagged version of znfe in the dependency list
- [x] move initialization code to `ffi.rs`
- ~get rid of initialization through `lazy_static` in `runtime.rs`~ (left for later)

There is a counterpart in libtezos-ffi (`cyclic-linking-fix` branch) to this branch that is required for it to work correctly.