### PR TITLE
OSX build fixes + binaries from CI + Travis CI for OSX

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,3 @@
+[target.x86_64-apple-darwin]
+# Required in OSX so that the compiler allows undefined symbols when linking dynamic libraries
+rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,14 @@ language: rust
 rust:
   - nightly-2020-07-12
 
-os:
-  - linux
-
-dist: focal
+jobs:
+  include:
+  - os: linux
+    dist: focal
+    name: Ubuntu Focal (20.04)
+  - os: osx
+    name: macOS Catalina (10.15)
+    osx_image: xcode12
 
 sudo: false
 
@@ -26,6 +30,23 @@ addons:
       - clang
       - libsodium-dev
       - libev4
+  homebrew:
+    packages:
+      - pkg-config
+      - gmp
+      - libev
+      - libsodium
+
+before_cache:
+  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+      brew cleanup;
+      find /usr/local/Homebrew \! -regex ".+\.git.+" -delete;
+    fi;
+
+cache:
+  directories:
+    - $HOME/Library/Caches/Homebrew
+    - /usr/local/Homebrew
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,17 +37,6 @@ addons:
       - libev
       - libsodium
 
-before_cache:
-  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      brew cleanup;
-      find /usr/local/Homebrew \! -regex ".+\.git.+" -delete;
-    fi;
-
-cache:
-  directories:
-    - $HOME/Library/Caches/Homebrew
-    - /usr/local/Homebrew
-
 branches:
   only:
     - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New configuration parameter `--disable-bootstrap-lookup` to turn off dns lookup for peers (e.g. used for tests or sandbox)
 - New configuration parameter `--db-cfg-max-threads` and `--db-cfg-max-open-files` to better control system resources
 - New RPCs to make baking in sandbox mode possible with tezos-client
+- Support for macOS (10.13 and newer).
 
 ### Changed
 
 - Resolved various clippy warnings/errors.
 - Drone test runs offline with carthagenet-snapshoted nodes.
-- New ocaml ffi - `ocaml-rs` was replaced with custom new library based on `ocaml-oxide` to get GC under control and better performance
+- New ocaml ffi - `ocaml-rs` was replaced with custom new library based on `caml-oxide` to get GC under control and better performance
 - P2P bootstrap process - NACK version control after metadata exchange
 
 ### Deprecated
@@ -100,7 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove bitvec dependency
 - Refactored FFI to Ocaml not using BigArray1's for better GC processing
- 
+
 ## [0.0.1] - 2020-03-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 dependencies = [
- "nom 5.1.2",
+ "nom",
 ]
 
 [[package]]
@@ -362,7 +362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
 dependencies = [
  "lazy_static",
- "nom 5.1.2",
+ "nom",
  "rust-ini",
  "serde 1.0.114",
  "serde-hjson",
@@ -1610,12 +1610,6 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf51a729ecf40266a2368ad335a5fdde43471f545a967109cd62146ecf8b66ff"
-
-[[package]]
-name = "nom"
 version = "5.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
@@ -1908,18 +1902,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
 dependencies = [
  "unicode-xid 0.2.0",
-]
-
-[[package]]
-name = "procinfo"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab1427f3d2635891f842892dda177883dca0639e05fe66796a62c9d2f23b49c"
-dependencies = [
- "byteorder",
- "libc",
- "nom 2.2.1",
- "rustc_version",
 ]
 
 [[package]]
@@ -2375,7 +2357,6 @@ dependencies = [
  "networking",
  "nix",
  "page_size",
- "procinfo",
  "r2d2",
  "rand",
  "regex",

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 [release-link]: https://github.com/simplestaking/tezedge/releases/latest
 
 The purpose of this project is to implement a secure, trustworthy, open-source Tezos node in Rust.
-In addition to implementing a new node, the project seeks to maintain and improve the Tezos node wherever possible. 
+In addition to implementing a new node, the project seeks to maintain and improve the Tezos node wherever possible.
 
 [Documentation][Docs Link]
 
@@ -34,7 +34,7 @@ Quick start
 
 **Pre-requisites**
 
-* GitHub repository 
+* GitHub repository
 
 * Docker
 
@@ -56,7 +56,7 @@ docker-compose up
 
 ![alt text](https://raw.githubusercontent.com/simplestaking/tezedge/master/docs/images/node_bootstrap.gif)
 
-**3. Open the TezEdge Explorer in your browser** 
+**3. Open the TezEdge Explorer in your browser**
 
 You can view the status of the node in your browser by entering this address into your browser's URL bar:
 
@@ -67,7 +67,7 @@ http://localhost:8080
 Building from Source
 ------------
 
-**1. Install rustup command** 
+**1. Install rustup command**
 
 We recommend installing Rust through rustup.
 
@@ -77,7 +77,7 @@ Run the following in your terminal, then follow the onscreen instructions.
 curl https://sh.rustup.rs -sSf | sh
 ```
 
-**2. Install rust toolchain** 
+**2. Install rust toolchain**
 
 Rust nightly is required to build this project.
 ```
@@ -97,6 +97,11 @@ Install libs required to build RocksDB package:
 sudo apt install clang libclang-dev llvm llvm-dev linux-kernel-headers libev-dev
 ```
 
+In OSX, using [Homebrew](https://brew.sh/):
+```
+brew install pkg-config gmp libev libsodium
+```
+
 **4. Supported Linux distributions**
 
 We are linking rust code with pre-compiled Tezos shared library. For your convenience we have created pre-compiled binary files
@@ -107,14 +112,17 @@ supported linux distributions:
 * Debian (9, 10 )
 * OpenSUSE (15.1, 15.2)
 * CentOS (7, 8)
-    
+
 If you are missing support for your favorite linux distribution on a poll request at [tezos-opam-builder](https://github.com/simplestaking/tezos-opam-builder) project.
 
+**5. Supported MacOS versions**
+
+Versions newer or equal to 10.13 should work.
 
 Running node manually
 ----------------
 
-The node can built through the `cargo build` or `cargo build --release`, be aware, release build can take 
+The node can built through the `cargo build` or `cargo build --release`, be aware, release build can take
 much longer to compile. environment variable `SODIUM_USE_PKG_CONFIG=1` mus be set. Put together, node can be build, for example, like this:
 ```
 SODIUM_USE_PKG_CONFIG=1 cargo build
@@ -126,7 +134,7 @@ by `protocol-runner`. Put together, node can be run, for example, like this:
 LD_LIBRARY_PATH=./tezos/interop/lib_tezos/artifacts cargo run --bin light-node -- --config-file ./light_node/etc/tezedge/tezedge.config
 ```
 
-All parameters can be provided also as command line arguments in the same format as in config file, in which case 
+All parameters can be provided also as command line arguments in the same format as in config file, in which case
 they have higher priority than the ones in config file. For example we can use the default config and change the log file path:
 ```
 LD_LIBRARY_PATH=./tezos/interop/lib_tezos/artifacts cargo run --bin light-node -- --config-file ./light_node/etc/tezedge/tezedge.config --log-file /tmp/logs/tezdge.log
@@ -140,7 +148,7 @@ Running node using run.sh script
 ----------------
 
 
-On linux systems, we prepared convenience script to run the node. It will automatically set all necessary environmnent variables, build and run tezedge node. 
+On linux systems, we prepared convenience script to run the node. It will automatically set all necessary environmnent variables, build and run tezedge node.
 All arguments can be provided to the `run.sh` script in the same manner as described in the previous section - Running Tezedge node manually.
 
 The following command will execute node in debug node:

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -32,7 +32,6 @@ tezos_wrapper = { path = "../tezos/wrapper" }
 
 [dev-dependencies]
 jsonpath = "0.1.1"
-procinfo = "0.4.2"
 r2d2 = "0.8.9"
 serial_test = "0.4"
 slog-async = "2.5"

--- a/shell/tests/actors_apply_blocks_test.rs
+++ b/shell/tests/actors_apply_blocks_test.rs
@@ -148,7 +148,6 @@ fn test_actors_apply_blocks_and_check_context_and_mempool() -> Result<(), failur
 
 
     let clocks = Instant::now();
-    let memory_before = procinfo::pid::statm_self().unwrap().resident;
 
     // 1. test - apply and context - prepare data for apply blocks and wait for current head, and check context
     assert!(
@@ -173,14 +172,7 @@ fn test_actors_apply_blocks_and_check_context_and_mempool() -> Result<(), failur
     );
 
     let clocks = clocks.elapsed();
-    let memory_after = procinfo::pid::statm_self().unwrap().resident;
-    println!(
-        "\nDone in {:?}! mem_before: {}, mem_after: {}, diff: {}",
-        clocks,
-        memory_before,
-        memory_after,
-        memory_after - memory_before
-    );
+    println!("\nDone in {:?}!", clocks);
 
     // clean up
     // shutdown events listening
@@ -303,7 +295,6 @@ fn test_scenario_for_apply_blocks_with_chain_feeder_and_check_context(
     let chain_id = tezos_env.main_chain_id().expect("invalid chain id");
 
     let clocks = Instant::now();
-    let memory_before = procinfo::pid::statm_self().unwrap().resident;
 
     // let's insert stored requests to database
     for request in requests {
@@ -337,14 +328,7 @@ fn test_scenario_for_apply_blocks_with_chain_feeder_and_check_context(
     }
 
     let clocks = clocks.elapsed();
-    let memory_after = procinfo::pid::statm_self().unwrap().resident;
-    println!(
-        "\n[Insert] done in {:?}! mem_before: {}, mem_after: {}, diff: {}",
-        clocks,
-        memory_before,
-        memory_after,
-        memory_after - memory_before
-    );
+    println!("\n[Insert] done in {:?}!", clocks);
 
     // wait context_listener to finished context for applied blocks
     info!(log, "Waiting for context processing"; "level" => apply_to_level);

--- a/tezos/interop/.cargo/config
+++ b/tezos/interop/.cargo/config
@@ -1,0 +1,3 @@
+[build]
+# Required in OSX so that the compiler allows undefined symbols in dynamic libraries
+rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]

--- a/tezos/interop/.cargo/config
+++ b/tezos/interop/.cargo/config
@@ -1,3 +1,0 @@
-[build]
-# Required in OSX so that the compiler allows undefined symbols in dynamic libraries
-rustflags = ["-C", "link-args=-Wl,-undefined,dynamic_lookup"]

--- a/tezos/interop/build.rs
+++ b/tezos/interop/build.rs
@@ -38,6 +38,7 @@ fn get_remote_lib() -> RemoteLib {
     println!("Resolved known artifacts: {:?}", &artifacts);
 
     let artifact_for_platform = match platform.os_type {
+        OSType::OSX => Some("libtezos-ffi-macos.dylib"),
         OSType::Ubuntu => match platform.version.as_str() {
             "16.04" => Some("libtezos-ffi-ubuntu16.so"),
             "18.04" | "18.10" => Some("libtezos-ffi-ubuntu18.so"),
@@ -128,7 +129,12 @@ fn run_builder(build_chain: &str) {
                 .expect("Couldn't run builder. Do you have opam and dune installed on your machine?");
         }
         "remote" => {
-            let libtezos_path = Path::new("lib_tezos").join("artifacts").join("libtezos.so");
+            let platform = current_platform();
+            let libtezos_filename = match platform.os_type {
+                OSType::OSX => "libtezos.dylib",
+                _ => "libtezos.so",
+            };
+            let libtezos_path = Path::new("lib_tezos").join("artifacts").join(libtezos_filename);
             let remote_lib = get_remote_lib();
             println!("Resolved platform-dependent remote_lib: {:?}", &remote_lib);
 

--- a/tezos/interop/lib_tezos/Makefile
+++ b/tezos/interop/lib_tezos/Makefile
@@ -1,6 +1,12 @@
 OBJDIR = artifacts
 TEZOS_BASE_DIR?=src
 
+ifeq ($(shell uname -s),Darwin) # OSX
+	LIB_EXTENSION=.dylib
+else
+	LIB_EXTENSION=.so
+endif
+
 all: package
 
 package: build
@@ -9,7 +15,7 @@ package: build
 build: build-deps
 		cd ${TEZOS_BASE_DIR} && opam config exec -- make
 		mkdir -p $(OBJDIR)
-		mv ${TEZOS_BASE_DIR}/libtezos-ffi.so $(OBJDIR)/libtezos.so
+		mv ${TEZOS_BASE_DIR}/libtezos-ffi.so $(OBJDIR)/libtezos${LIB_EXTENSION}
 
 build-deps:
 		cd ${TEZOS_BASE_DIR} && OPAMYES=1 make build-deps


### PR DESCRIPTION
- [x] OSX build fixes + use binaries from Gitlab CI
- [x] Travis CI for OSX
- [x] recompile libtezos so that it works with OSX 10.13 and newer
- [x] Caching of OSX stuff for faster builds (half-done, needs more work)
- [x] Fix post-accept issue with sockets in OSX (https://bugs.python.org/issue7995)
  - https://github.com/dotnet/runtime/issues/25069 and https://bugs.python.org/issue7995
- [x] linker settings for OSX as part of the project (no need for the user to set it up)
- [x] instructions for OSX in README (homebrew deps)
