### PR TITLE
Enable core dumps for the node and increase max open files limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New configuration parameter `--disable-bootstrap-lookup` to turn off dns lookup for peers (e.g. used for tests or sandbox)
-- New configuration parameter `--db-cfg-max-threads` and `--db-cfg-max-open-files` to better control system resources
+- New configuration parameter `--db-cfg-max-threads` to better control system resources
 - New RPCs to make baking in sandbox mode possible with tezos-client
 - Support for macOS (10.13 and newer).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,6 +1356,7 @@ dependencies = [
  "monitoring",
  "networking",
  "riker",
+ "rlimit",
  "rpc",
  "serde 1.0.114",
  "serde_json",
@@ -2112,6 +2113,16 @@ name = "rle-decode-fast"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
+
+[[package]]
+name = "rlimit"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b02d62c38353a6fce45c25ca19783e25dd5f495ca681c674a4ee15aa4c1536"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "rocksdb"

--- a/light_node/Cargo.toml
+++ b/light_node/Cargo.toml
@@ -13,6 +13,7 @@ futures = "0.3"
 hex = "0.4"
 lazy_static = "1.4"
 riker = "0.4"
+rlimit = "0.4.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slog = { version = "2.5", features = ["max_level_trace"] }

--- a/light_node/README.md
+++ b/light_node/README.md
@@ -45,11 +45,6 @@ contains valid database, node will continue in bootstrap process on that databas
 --db-cfg-max-threads <NUM>
 ```
 
-```
-#Max open files for database. If specified '-1', means unlimited. Default value: 512
---db-cfg-max-open-files <NUM>
-```
-
 -----
 
 ### Bootstrap lookup addresses

--- a/light_node/etc/tezedge/tezedge.config
+++ b/light_node/etc/tezedge/tezedge.config
@@ -30,9 +30,6 @@
 #Max number of threads used by database configuration. If not specified, then number of threads equal to CPU cores.
 #--db-cfg-max-threads <NUM>
 
-#Max open files for database. If specified '-1', means unlimited. Default value: 512
-#--db-cfg-max-open-files <NUM>
-
 # <Optional> A peers for dns lookup to get the peers to bootstrap the network from. Peers are delimited by a colon.
 # Default: used according to --network parameter see TezosEnvironment
 # --bootstrap-lookup-address <bootstrap-lookup-address>

--- a/light_node/src/configuration.rs
+++ b/light_node/src/configuration.rs
@@ -156,12 +156,6 @@ pub fn tezos_app() -> App<'static, 'static> {
             .value_name("NUM")
             .help("Max number of threads used by database configuration. If not specified, then number of threads equal to CPU cores.")
             .validator(parse_validator_fn!(usize, "Value must be a valid number")))
-        .arg(Arg::with_name("db-cfg-max-open-files")
-            .long("db-cfg-max-open-files")
-            .takes_value(true)
-            .value_name("NUM")
-            .help("Max open files for database. If specified '-1', means unlimited. Default value: 512")
-            .validator(parse_validator_fn!(i32, "Value must be a valid number")))
         .arg(Arg::with_name("bootstrap-lookup-address")
             .long("bootstrap-lookup-address")
             .takes_value(true)
@@ -552,12 +546,6 @@ impl Environment {
                             .parse::<usize>()
                             .expect("Provided value cannot be converted to number");
                         db_cfg.max_threads(Some(max_treads));
-                    }
-                    if let Some(value) = args.value_of("db-cfg-max-open-files") {
-                        let max_open_files = value
-                            .parse::<i32>()
-                            .expect("Provided value cannot be converted to number");
-                        db_cfg.max_open_files(max_open_files);
                     }
 
                     db_cfg.build().unwrap()

--- a/light_node/src/main.rs
+++ b/light_node/src/main.rs
@@ -36,6 +36,7 @@ use crate::configuration::LogFormat;
 
 mod configuration;
 mod identity;
+mod system;
 
 const DATABASE_VERSION: i64 = 15;
 const SUPPORTED_DISTRIBUTED_DB_VERSION: u16 = 0;
@@ -251,6 +252,9 @@ fn main() {
 
     // Creates default logger
     let log = create_logger(&env);
+
+    // Enable core dumps
+    system::init_limits(&log);
 
     let actor_system = SystemBuilder::new().name("light-node").log(log.clone()).create().expect("Failed to create actor system");
 

--- a/light_node/src/main.rs
+++ b/light_node/src/main.rs
@@ -253,7 +253,7 @@ fn main() {
     // Creates default logger
     let log = create_logger(&env);
 
-    // Enable core dumps
+    // Enable core dumps and increase open files limit
     system::init_limits(&log);
 
     let actor_system = SystemBuilder::new().name("light-node").log(log.clone()).create().expect("Failed to create actor system");

--- a/light_node/src/system.rs
+++ b/light_node/src/system.rs
@@ -1,9 +1,12 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use std::cmp;
 use rlimit;
 
 use slog::{info, error, Logger};
+
+const OPEN_FILES_LIMIT: u64 = 64 * 1024; //64k open files limit for process
 
 // Enables and sets maximum size for core dump file if it was not set before
 // If user set a non-zero limit before, it will be left as is
@@ -32,6 +35,33 @@ unsafe fn enable_core_dumps(log: &Logger) {
     }
 }
 
+// Sets the limit of open file descriptors for the process
+// If user set a higher limit before, it will be left as is
+unsafe fn set_file_desc_limit(log: &Logger, num : u64) {
+    // Get current open file desc limit
+    let rlim = match rlimit::getrlimit(rlimit::Resource::NOFILE) {
+        Ok(rlim) => rlim,
+        Err(e) => {
+            error!(log, "Setting open files limit failed (getrlimit): {}", e);
+            return;
+        }
+    };
+    let (mut soft, hard) = rlim;
+    // If the currently set rlimit is higher, do not change it
+    if soft >= num {
+        return;
+    }
+    // Set rlimit to num, but not higher than hard limit
+    soft = cmp::min(num, hard);
+    match rlimit::setrlimit(rlimit::Resource::NOFILE, soft, hard) {
+        Ok(()) => info!(log, "Open files limit set to {}.", soft),
+        Err(e) => {
+            error!(log,"Setting open files limit failed (setrlimit): {}", e);
+            return;
+        }
+    }
+}
+
 pub fn init_limits(log: &Logger) {
     // Need unsafe to access direct libc syscall interface
     unsafe {
@@ -39,5 +69,7 @@ pub fn init_limits(log: &Logger) {
         if cfg!(debug_assertions) {
             enable_core_dumps(&log);
         }
+        // Increase open files rlimit to 64k
+        set_file_desc_limit(&log, OPEN_FILES_LIMIT);
     }
 }

--- a/light_node/src/system.rs
+++ b/light_node/src/system.rs
@@ -1,0 +1,43 @@
+// Copyright (c) SimpleStaking and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use rlimit;
+
+use slog::{info, error, Logger};
+
+// Enables and sets maximum size for core dump file if it was not set before
+// If user set a non-zero limit before, it will be left as is
+unsafe fn enable_core_dumps(log: &Logger) {
+    // Get current size limit of core dumps
+    let rlim = match rlimit::getrlimit(rlimit::Resource::CORE) {
+        Ok(rlim) => rlim,
+        Err(e) => {
+            error!(log, "Enabling core dumps failed (getrlimit): {}", e);
+            return;
+        }
+    };
+    let (mut soft, hard) = rlim;
+    // Bump soft limit to the hard limit, but only if it was not set before
+    if soft == 0 {
+        soft = hard;
+        if soft > 0 {
+            match rlimit::setrlimit(rlimit::Resource::CORE, soft, hard) {
+                Ok(()) => info!(log, "Core dumps enabled with maximum size."),
+                Err(e) => {
+                    error!(log,"Enabling core dumps failed (setrlimit): {}", e);
+                    return;
+                }
+            }
+        }
+    }
+}
+
+pub fn init_limits(log: &Logger) {
+    // Need unsafe to access direct libc syscall interface
+    unsafe {
+        // Enable core dumps for debug build
+        if cfg!(debug_assertions) {
+            enable_core_dumps(&log);
+        }
+    }
+}

--- a/storage/src/persistent/mod.rs
+++ b/storage/src/persistent/mod.rs
@@ -23,12 +23,9 @@ pub mod database;
 pub mod commit_log;
 
 /// Rocksdb database system configuration
-/// - [max_open_files] - default is 512, but depends on system limits (like ulimit)
 /// - [max_num_of_threads] - if not set, num of cpus is used
 #[derive(Builder, Debug, Clone)]
 pub struct DbConfiguration {
-    #[builder(default = "512")]
-    max_open_files: i32,
     #[builder(default = "None")]
     max_threads: Option<usize>,
 }
@@ -68,7 +65,6 @@ fn default_kv_options(cfg: &DbConfiguration) -> Options {
     db_opts.set_level_compaction_dynamic_level_bytes(true);
     db_opts.set_max_background_compactions(4);
     db_opts.set_max_background_flushes(2);
-    db_opts.set_max_open_files(cfg.max_open_files);
 
     // resolve thread count to use
     let num_of_threads = match cfg.max_threads {


### PR DESCRIPTION
On node startup, enable core dumps for debug builds. Also increase the limit of max open file descriptors to 64k.
Unsafe block is required to use direct libc syscall functions.
Also remove the db-cfg-max-open-files setting and leave the default RocksDB value (unlimited).
More details in commit logs.