### PR TITLE
[TE-285] support for in memory merkle storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -907,6 +907,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1141,15 @@ dependencies = [
  "honggfuzz",
  "log",
  "tezos_messages",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -2560,6 +2579,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec448bc157977efdc0a71369cf923915b0c4806b1b2449c3fb011071d6f7c38"
+dependencies = [
+ "cfg-if 0.1.10",
+ "proc-macro2 1.0.24",
+ "quote 1.0.8",
+ "rustc_version",
+ "syn 1.0.58",
+]
+
+[[package]]
 name = "rust-argon2"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2878,6 +2910,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
+name = "sled"
+version = "0.34.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d0132f3e393bcb7390c60bb45769498cf4550bcb7a21d7f95c02b69f6362cdc"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot",
+]
+
+[[package]]
 name = "slog"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3009,8 +3057,10 @@ dependencies = [
  "num_cpus",
  "rand 0.7.3",
  "rocksdb",
+ "rstest",
  "serde 1.0.119",
  "serde_json",
+ "sled",
  "slog",
  "slog-async",
  "slog-term",

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -17,6 +17,7 @@ num_cpus = "1.13"
 rocksdb = "0.15"
 serde = { version = "1.0", features = ["derive", "rc"] }
 slog = "2.7"
+sled = "0.34.4"
 # local dependencies
 crypto = { path = "../crypto" }
 tezos_api = { path = "../tezos/api" }
@@ -32,6 +33,7 @@ assert-json-diff = "1.1"
 hex = "0.4"
 maplit = "1.0"
 rand = "0.7.3"
+rstest = "0.6.4"
 serde_json = "1.0"
 slog-async = "2.6"
 slog-term = "2.6"

--- a/storage/src/persistent/in_memory_backend.rs
+++ b/storage/src/persistent/in_memory_backend.rs
@@ -1,0 +1,116 @@
+use std::{cell::RefCell, collections::HashMap, path::PathBuf, sync::Mutex, unimplemented};
+
+use crate::persistent::database::{IteratorMode, IteratorWithSchema, RocksDBStats};
+use crate::persistent::{DBError, KeyValueSchema, KeyValueStoreWithSchema};
+
+use super::Codec;
+use crate::persistent::codec::{Decoder, Encoder};
+use sled;
+
+pub struct InMemoryStorage<S: KeyValueSchema> {
+    in_memory_data: Mutex<RefCell<HashMap<S::Key, S::Value>>>,
+    path: PathBuf,
+}
+
+impl<S: KeyValueSchema> InMemoryStorage<S>
+where
+    S::Key: Codec + std::cmp::Eq + std::hash::Hash,
+    S::Value: Codec,
+{
+    pub fn new(path: PathBuf) -> InMemoryStorage<S> {
+        let storage: InMemoryStorage<S> = InMemoryStorage {
+            in_memory_data: Mutex::new(RefCell::new(HashMap::new())),
+            path: path.clone(),
+        };
+
+        match sled::open(&storage.path) {
+            Ok(db) => {
+                for i in db.iter() {
+                    let data = i.expect("cannot read entry from db");
+                    let key = S::Key::decode(&data.0).unwrap();
+                    let val = S::Value::decode(&data.1).unwrap();
+                    storage
+                        .in_memory_data
+                        .lock()
+                        .unwrap()
+                        .borrow_mut()
+                        .insert(key, val);
+                }
+                storage
+            }
+            Err(_) => storage,
+        }
+    }
+}
+
+impl<S: KeyValueSchema> Drop for InMemoryStorage<S> {
+    fn drop(&mut self) {
+        let db = sled::Config::default().path(&self.path).open().unwrap();
+        db.clear().expect("cannot clear file storage");
+        for (k, v) in self.in_memory_data.lock().unwrap().borrow().iter() {
+            let key_bytes = k.encode().expect("cannot serialize key");
+            let value_bytes = v.encode().expect("cannot deserialize key");
+            db.insert(key_bytes, value_bytes)
+                .expect("cannot store data in psersitent storage");
+        }
+    }
+}
+
+// currently only part of the interface is used for MerkleStorage use case
+// where we want to use InMemoryStorage therefore part of the methods can be
+// implemented later
+impl<S> KeyValueStoreWithSchema<S> for InMemoryStorage<S>
+where
+    S: KeyValueSchema,
+    S::Key: std::cmp::Eq + std::hash::Hash,
+    S::Value: Clone,
+{
+    fn put(&self, _key: &S::Key, _value: &S::Value) -> Result<(), DBError> {
+        unimplemented!("Foo::put not implemented yet");
+    }
+
+    fn delete(&self, _key: &S::Key) -> Result<(), DBError> {
+        unimplemented!("Foo::delete not implemented yet");
+    }
+
+    fn merge(&self, _key: &S::Key, _value: &S::Value) -> Result<(), DBError> {
+        unimplemented!("Foo::merge not implemented yet");
+    }
+
+    fn get(&self, key: &S::Key) -> Result<Option<S::Value>, DBError> {
+        Ok(self
+            .in_memory_data
+            .lock()
+            .unwrap()
+            .borrow()
+            .get(key)
+            .map(|x| x.clone()))
+    }
+
+    fn iterator(&self, _mode: IteratorMode<S>) -> Result<IteratorWithSchema<S>, DBError> {
+        unimplemented!("Foo::iterator not implemented yet");
+    }
+
+    fn prefix_iterator(&self, _key: &S::Key) -> Result<IteratorWithSchema<S>, DBError> {
+        unimplemented!("Foo::prefix_iterator not implemented yet");
+    }
+
+    fn contains(&self, _key: &S::Key) -> Result<bool, DBError> {
+        unimplemented!("Foo::contains not implemented yet");
+    }
+
+    fn write(&self, batch: Vec<(S::Key, S::Value)>) -> Result<(), DBError> {
+        for (k, v) in batch.into_iter() {
+            self.in_memory_data
+                .lock()
+                .unwrap()
+                .borrow_mut()
+                .insert(k, v);
+        }
+        return Ok(());
+    }
+
+    fn get_mem_use_stats(&self) -> Result<RocksDBStats, DBError> {
+        unimplemented!("Foo::get_mem_use_stats not implemented yet");
+    }
+}

--- a/storage/src/persistent/mod.rs
+++ b/storage/src/persistent/mod.rs
@@ -10,6 +10,7 @@ use rocksdb::{BlockBasedOptions, Cache, ColumnFamilyDescriptor, Options, DB};
 pub use codec::{BincodeEncoded, Codec, Decoder, Encoder, SchemaError};
 pub use commit_log::{CommitLogError, CommitLogRef, CommitLogWithSchema, CommitLogs, Location};
 pub use database::{DBError, KeyValueStoreWithSchema};
+pub use in_memory_backend::InMemoryStorage;
 pub use schema::{CommitLogDescriptor, CommitLogSchema, KeyValueSchema};
 
 use crate::merkle_storage::MerkleStorage;
@@ -18,6 +19,7 @@ use crate::persistent::sequence::Sequences;
 pub mod codec;
 pub mod commit_log;
 pub mod database;
+pub mod in_memory_backend;
 pub mod schema;
 pub mod sequence;
 


### PR DESCRIPTION
`KeyValueStoreWithSchema` was modified in order to operate on object not bytes its up to concrete `KeyValueStoreWithSchema` implementation to perform serialization (while still `Schema::Key` and `Schema::Value` has Codec boundries). 

so now there are 2 implementations for `MerkleStorageKV`:
- rocketDb based (from database.rs)
- in memory - HashMap from `in_memory_backend.rs`

added parametrized tests for merkle storage. Now all the tests are run against above 2 backends.

Removed internal rocksdb's `WriteBatch` type that leaked to "our" public interface


proper error handling for InMemoryBackend needs to be added in the future