### PR TITLE
[TE-276] Introduce an error on exceeding 128 size

### DIFF
--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -237,7 +237,12 @@ impl HashType {
             let mut hash = Vec::with_capacity(self.base58check_prefix().len() + data.len());
             hash.extend(self.base58check_prefix());
             hash.extend(data);
-            Ok(hash.to_base58check())
+            hash.to_base58check()
+                // currently the error is returned if the input lenght exceeds 128 bytes
+                // that is the limitation of base58 crate, and there are no hash types
+                // exceeding that limit.
+                // TODO: remove this when TE-373 is implemented
+                .map_err(|_| unreachable!("Hash size should not exceed allowed 128 bytes"))
         }
     }
 


### PR DESCRIPTION
This is the fix in the case we don't want to replace `base58` crate. Now our base58 refuses to accept data/strings longer than 128 bytes.

This is still a compromised solution. It is possible to introduce a completely new hash type longer than 128 bytes that will cause panic, but that will be discovered very early during development. Also user input does not affect the length of the hashes being encoded. For decoding the error will be reported. 