### PR TITLE
[TE-228] Introduce individual types for hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -611,6 +611,7 @@ dependencies = [
  "num-bigint",
  "num-traits 0.2.14",
  "rand 0.7.3",
+ "serde 1.0.119",
  "sodiumoxide",
 ]
 

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -13,3 +13,4 @@ num-bigint = { version = "0.3", features = ["serde", "rand"] }
 num-traits = "0.2.8"
 rand = "0.7.3"
 sodiumoxide = "0.2.5"
+serde = { version = "1.0", features = ["derive"] }

--- a/crypto/src/crypto_box.rs
+++ b/crypto/src/crypto_box.rs
@@ -12,6 +12,8 @@
 //!
 //! CryptoboxPublicKeyHash - generated as a hash of [`PublicKey`], for example used as a peer_id
 
+use std::convert::TryFrom;
+
 use hex::{FromHex, FromHexError};
 use sodiumoxide::crypto::box_;
 
@@ -50,7 +52,8 @@ pub struct PublicKey(box_::PublicKey);
 impl PublicKey {
     /// Generates public key hash for public key
     pub fn public_key_hash(&self) -> CryptoboxPublicKeyHash {
-        crate::blake2b::digest_128(self.0.as_ref())
+        CryptoboxPublicKeyHash::try_from(crate::blake2b::digest_128(self.0.as_ref()))
+            .unwrap_or_else(|_| unreachable!())
     }
 }
 

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -42,7 +42,17 @@ pub enum FromBytesError {
 
 macro_rules! define_hash {
     ($name:ident) => {
-        #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, std::cmp::PartialOrd, std::cmp::Ord, std::hash::Hash)]
+        #[derive(
+            Debug,
+            Clone,
+            PartialEq,
+            Eq,
+            Serialize,
+            Deserialize,
+            std::cmp::PartialOrd,
+            std::cmp::Ord,
+            std::hash::Hash,
+        )]
         pub struct $name(pub Hash);
 
         impl $name {
@@ -348,11 +358,10 @@ mod tests {
 
     #[test]
     fn test_encode_block_header_new() -> Result<(), failure::Error> {
-        let encoded = BlockHash
-            ::from_bytes(&hex::decode(
-                "46a6aefde9243ae18b191a8d010b7237d5130b3530ce5d1f60457411b2fa632d",
-            )?)?
-            .to_base58_check();
+        let encoded = BlockHash::from_bytes(&hex::decode(
+            "46a6aefde9243ae18b191a8d010b7237d5130b3530ce5d1f60457411b2fa632d",
+        )?)?
+        .to_base58_check();
         let expected = "BLFQ2JjYWHC95Db21cRZC4cgyA1mcXmx1Eg6jKywWy9b8xLzyK9";
         assert_eq!(expected, encoded);
 
@@ -506,8 +515,8 @@ mod tests {
 
     #[test]
     fn test_decode_protocol_hash() -> Result<(), failure::Error> {
-        let decoded = ProtocolHash
-            ::from_base58_check("PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb")?;
+        let decoded =
+            ProtocolHash::from_base58_check("PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb")?;
         let decoded = hex::encode(decoded.as_ref());
         let expected = "3e5e3a606afab74a59ca09e333633e2770b6492c5e594455b71e9a2f0ea92afb";
         assert_eq!(expected, decoded);

--- a/crypto/src/hash.rs
+++ b/crypto/src/hash.rs
@@ -1,7 +1,10 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use std::convert::TryFrom;
+
 use crate::base58::{FromBase58Check, FromBase58CheckError, ToBase58Check};
+use serde::{Deserialize, Serialize};
 
 mod prefix_bytes {
     pub const CHAIN_ID: [u8; 3] = [87, 82, 0];
@@ -24,22 +27,111 @@ mod prefix_bytes {
 }
 
 pub type Hash = Vec<u8>;
-pub type ChainId = Hash;
-pub type BlockHash = Hash;
-pub type BlockMetadataHash = Hash;
-pub type OperationHash = Hash;
-pub type OperationListListHash = Hash;
-pub type OperationMetadataHash = Hash;
-pub type OperationMetadataListListHash = Hash;
-pub type ContextHash = Hash;
-pub type ProtocolHash = Hash;
-pub type ContractTz1Hash = Hash;
-pub type ContractTz2Hash = Hash;
-pub type ContractTz3Hash = Hash;
-pub type CryptoboxPublicKeyHash = Hash;
-pub type PublicKeyEd25519 = Hash;
-pub type PublicKeySecp256k1 = Hash;
-pub type PublicKeyP256 = Hash;
+
+pub trait HashTrait: Into<Hash> + AsRef<Hash> {
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self, FromBytesError>;
+}
+
+/// Error creating hash from bytes
+#[derive(Debug, failure::Fail)]
+pub enum FromBytesError {
+    /// Invalid data size
+    #[fail(display = "invalid hash size")]
+    InvalidSize,
+}
+
+macro_rules! define_hash {
+    ($name:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, std::cmp::PartialOrd, std::cmp::Ord, std::hash::Hash)]
+        pub struct $name(pub Hash);
+
+        impl $name {
+            pub fn from_base58_check(data: &str) -> Result<Self, FromBase58CheckError> {
+                HashType::$name.b58check_to_hash(data).map(|h| Self(h))
+            }
+
+            fn from_bytes(data: &[u8]) -> Result<Self, FromBytesError> {
+                if data.len() == HashType::$name.size() {
+                    Ok($name(data.into()))
+                } else {
+                    Err(FromBytesError::InvalidSize)
+                }
+            }
+
+            fn from_vec(hash: Vec<u8>) -> Result<Self, FromBytesError> {
+                if hash.len() == HashType::$name.size() {
+                    Ok($name(hash))
+                } else {
+                    Err(FromBytesError::InvalidSize)
+                }
+            }
+
+            pub fn to_base58_check(&self) -> String {
+                // error is reported only if data lenght mismatches type size
+                HashType::$name
+                    .hash_to_b58check(&self.0)
+                    .unwrap_or_else(|_| unreachable!())
+            }
+        }
+
+        impl HashTrait for $name {
+            fn try_from_bytes(bytes: &[u8]) -> Result<Self, FromBytesError> {
+                $name::try_from(bytes)
+            }
+        }
+
+        impl std::convert::AsRef<Hash> for $name {
+            fn as_ref(&self) -> &Hash {
+                &self.0
+            }
+        }
+
+        impl std::convert::Into<Hash> for $name {
+            fn into(self) -> Hash {
+                self.0
+            }
+        }
+
+        impl std::convert::TryFrom<&[u8]> for $name {
+            type Error = FromBytesError;
+            fn try_from(h: &[u8]) -> Result<Self, Self::Error> {
+                Self::from_bytes(h)
+            }
+        }
+
+        impl std::convert::TryFrom<Hash> for $name {
+            type Error = FromBytesError;
+            fn try_from(h: Hash) -> Result<Self, Self::Error> {
+                Self::from_vec(h)
+            }
+        }
+
+        impl std::convert::TryFrom<&str> for $name {
+            type Error = FromBase58CheckError;
+            fn try_from(encoded: &str) -> Result<Self, Self::Error> {
+                Self::from_base58_check(encoded)
+            }
+        }
+    };
+}
+
+define_hash!(ChainId);
+define_hash!(BlockHash);
+define_hash!(BlockMetadataHash);
+define_hash!(OperationHash);
+define_hash!(OperationListListHash);
+define_hash!(OperationMetadataHash);
+define_hash!(OperationMetadataListListHash);
+define_hash!(ContextHash);
+define_hash!(ProtocolHash);
+define_hash!(ContractKt1Hash);
+define_hash!(ContractTz1Hash);
+define_hash!(ContractTz2Hash);
+define_hash!(ContractTz3Hash);
+define_hash!(CryptoboxPublicKeyHash);
+define_hash!(PublicKeyEd25519);
+define_hash!(PublicKeySecp256k1);
+define_hash!(PublicKeyP256);
 
 /// Note: see Tezos ocaml lib_crypto/base58.ml
 #[derive(Debug, Copy, Clone)]
@@ -128,18 +220,15 @@ impl HashType {
     }
 
     /// Convert hash byte representation into string.
-    pub fn hash_to_b58check(&self, data: &[u8]) -> String {
-        assert_eq!(
-            self.size(),
-            data.len(),
-            "Expected data length is {} but instead found {}",
-            self.size(),
-            data.len()
-        );
-        let mut hash = Vec::with_capacity(self.base58check_prefix().len() + data.len());
-        hash.extend(self.base58check_prefix());
-        hash.extend(data);
-        hash.to_base58check()
+    pub fn hash_to_b58check(&self, data: &[u8]) -> Result<String, FromBytesError> {
+        if self.size() != data.len() {
+            Err(FromBytesError::InvalidSize)
+        } else {
+            let mut hash = Vec::with_capacity(self.base58check_prefix().len() + data.len());
+            hash.extend(self.base58check_prefix());
+            hash.extend(data);
+            Ok(hash.to_base58check())
+        }
     }
 
     /// Convert string representation of the hash to bytes form.
@@ -161,14 +250,14 @@ impl HashType {
 
 #[inline]
 pub fn chain_id_to_b58_string(chain_id: &ChainId) -> String {
-    HashType::ChainId.hash_to_b58check(chain_id)
+    chain_id.to_base58_check()
 }
 
 /// Implementation of chain_id.ml -> of_block_hash
 #[inline]
 pub fn chain_id_from_block_hash(block_hash: &BlockHash) -> ChainId {
-    let result = crate::blake2b::digest_256(block_hash);
-    result[0..4].to_vec()
+    let result = crate::blake2b::digest_256(&block_hash.0);
+    ChainId::from_bytes(&result[0..4]).unwrap_or_else(|_| unreachable!())
 }
 
 #[cfg(test)]
@@ -179,7 +268,7 @@ mod tests {
 
     #[test]
     fn test_encode_chain_id() -> Result<(), failure::Error> {
-        let decoded = HashType::ChainId.hash_to_b58check(&hex::decode("8eceda2f")?);
+        let decoded = HashType::ChainId.hash_to_b58check(&hex::decode("8eceda2f")?)?;
         let expected = "NetXgtSLGNJvNye";
         assert_eq!(expected, decoded);
 
@@ -188,27 +277,34 @@ mod tests {
 
     #[test]
     fn test_chain_id_to_b58_string() -> Result<(), failure::Error> {
-        let decoded = chain_id_to_b58_string(&hex::decode("8eceda2f")?);
+        let encoded = chain_id_to_b58_string(&ChainId::from_bytes(&hex::decode("8eceda2f")?)?);
         let expected = "NetXgtSLGNJvNye";
-        assert_eq!(expected, decoded);
+        assert_eq!(expected, encoded);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_chain_id_to_base58_check() -> Result<(), failure::Error> {
+        let encoded = ChainId::from_bytes(&hex::decode("8eceda2f")?)?.to_base58_check();
+        let expected = "NetXgtSLGNJvNye";
+        assert_eq!(expected, encoded);
 
         Ok(())
     }
 
     #[test]
     fn test_chain_id_from_block_hash() -> Result<(), failure::Error> {
-        let decoded_chain_id: ChainId = chain_id_from_block_hash(
-            &HashType::BlockHash
-                .b58check_to_hash("BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe")?,
-        );
+        let decoded_chain_id: ChainId = chain_id_from_block_hash(&BlockHash::from_base58_check(
+            "BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe",
+        )?);
         let decoded_chain_id: &str = &chain_id_to_b58_string(&decoded_chain_id);
         let expected_chain_id = "NetXgtSLGNJvNye";
         assert_eq!(expected_chain_id, decoded_chain_id);
 
-        let decoded_chain_id: ChainId = chain_id_from_block_hash(
-            &HashType::BlockHash
-                .b58check_to_hash("BLockGenesisGenesisGenesisGenesisGenesisd6f5afWyME7")?,
-        );
+        let decoded_chain_id: ChainId = chain_id_from_block_hash(&BlockHash::from_base58_check(
+            "BLockGenesisGenesisGenesisGenesisGenesisd6f5afWyME7",
+        )?);
         let decoded_chain_id: &str = &chain_id_to_b58_string(&decoded_chain_id);
         let expected_chain_id = "NetXjD3HPJJjmcd";
         assert_eq!(expected_chain_id, decoded_chain_id);
@@ -218,22 +314,47 @@ mod tests {
 
     #[test]
     fn test_encode_block_header_genesis() -> Result<(), failure::Error> {
-        let decoded = HashType::BlockHash.hash_to_b58check(&hex::decode(
+        let encoded = HashType::BlockHash.hash_to_b58check(&hex::decode(
             "8fcf233671b6a04fcf679d2a381c2544ea6c1ea29ba6157776ed8424affa610d",
-        )?);
+        )?)?;
         let expected = "BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe";
-        assert_eq!(expected, decoded);
+        assert_eq!(expected, encoded);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_encode_block_header_genesis_new() -> Result<(), failure::Error> {
+        let encoded = BlockHash::from_bytes(&hex::decode(
+            "8fcf233671b6a04fcf679d2a381c2544ea6c1ea29ba6157776ed8424affa610d",
+        )?)?
+        .to_base58_check();
+        let expected = "BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe";
+        assert_eq!(expected, encoded);
 
         Ok(())
     }
 
     #[test]
     fn test_encode_block_header() -> Result<(), failure::Error> {
-        let decoded = HashType::BlockHash.hash_to_b58check(&hex::decode(
+        let encoded = HashType::BlockHash.hash_to_b58check(&hex::decode(
             "46a6aefde9243ae18b191a8d010b7237d5130b3530ce5d1f60457411b2fa632d",
-        )?);
+        )?)?;
         let expected = "BLFQ2JjYWHC95Db21cRZC4cgyA1mcXmx1Eg6jKywWy9b8xLzyK9";
-        assert_eq!(expected, decoded);
+        assert_eq!(expected, encoded);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_encode_block_header_new() -> Result<(), failure::Error> {
+        let encoded = BlockHash
+            ::from_bytes(&hex::decode(
+                "46a6aefde9243ae18b191a8d010b7237d5130b3530ce5d1f60457411b2fa632d",
+            )?)?
+            .to_base58_check();
+        let expected = "BLFQ2JjYWHC95Db21cRZC4cgyA1mcXmx1Eg6jKywWy9b8xLzyK9";
+        assert_eq!(expected, encoded);
 
         Ok(())
     }
@@ -242,9 +363,21 @@ mod tests {
     fn test_encode_context() -> Result<(), failure::Error> {
         let decoded = HashType::ContextHash.hash_to_b58check(&hex::decode(
             "934484026d24be9ad40c98341c20e51092dd62bbf470bb9ff85061fa981ebbd9",
-        )?);
+        )?)?;
         let expected = "CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd";
         assert_eq!(expected, decoded);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_encode_context_new() -> Result<(), failure::Error> {
+        let encoded = ContextHash::from_bytes(&hex::decode(
+            "934484026d24be9ad40c98341c20e51092dd62bbf470bb9ff85061fa981ebbd9",
+        )?)?
+        .to_base58_check();
+        let expected = "CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd";
+        assert_eq!(expected, encoded);
 
         Ok(())
     }
@@ -253,9 +386,21 @@ mod tests {
     fn test_encode_operations_hash() -> Result<(), failure::Error> {
         let decoded = HashType::OperationListListHash.hash_to_b58check(&hex::decode(
             "acecbfac449678f1d68b90c7b7a86c9280fd373d872e072f3fb1b395681e7149",
-        )?);
+        )?)?;
         let expected = "LLoads9N8uB8v659hpNhpbrLzuzLdUCjz5euiR6Lm2hd7C6sS2Vep";
         assert_eq!(expected, decoded);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_encode_operations_hash_new() -> Result<(), failure::Error> {
+        let encoded = OperationListListHash::from_bytes(&hex::decode(
+            "acecbfac449678f1d68b90c7b7a86c9280fd373d872e072f3fb1b395681e7149",
+        )?)?
+        .to_base58_check();
+        let expected = "LLoads9N8uB8v659hpNhpbrLzuzLdUCjz5euiR6Lm2hd7C6sS2Vep";
+        assert_eq!(expected, encoded);
 
         Ok(())
     }
@@ -266,7 +411,20 @@ mod tests {
             "2cc1b580f4b8b1f6dbd0aa1d9cde2655c2081c07d7e61249aad8b11d954fb01a",
         )?;
         let pk_hash = pk.public_key_hash();
-        let decoded = HashType::CryptoboxPublicKeyHash.hash_to_b58check(pk_hash.as_ref());
+        let decoded = HashType::CryptoboxPublicKeyHash.hash_to_b58check(pk_hash.as_ref())?;
+        let expected = "idsg2wkkDDv2cbEMK4zH49fjgyn7XT";
+        assert_eq!(expected, decoded);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_encode_public_key_hash_new() -> Result<(), failure::Error> {
+        let pk = PublicKey::from_hex(
+            "2cc1b580f4b8b1f6dbd0aa1d9cde2655c2081c07d7e61249aad8b11d954fb01a",
+        )?;
+        let pk_hash = pk.public_key_hash();
+        let decoded = CryptoboxPublicKeyHash::from_bytes(pk_hash.as_ref())?.to_base58_check();
         let expected = "idsg2wkkDDv2cbEMK4zH49fjgyn7XT";
         assert_eq!(expected, decoded);
 
@@ -276,7 +434,18 @@ mod tests {
     #[test]
     fn test_encode_contract_tz1() -> Result<(), failure::Error> {
         let decoded = HashType::ContractTz1Hash
-            .hash_to_b58check(&hex::decode("83846eddd5d3c5ed96e962506253958649c84a74")?);
+            .hash_to_b58check(&hex::decode("83846eddd5d3c5ed96e962506253958649c84a74")?)?;
+        let expected = "tz1XdRrrqrMfsFKA8iuw53xHzug9ipr6MuHq";
+        assert_eq!(expected, decoded);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_encode_contract_tz1_new() -> Result<(), failure::Error> {
+        let decoded =
+            ContractTz1Hash::from_bytes(&hex::decode("83846eddd5d3c5ed96e962506253958649c84a74")?)?
+                .to_base58_check();
         let expected = "tz1XdRrrqrMfsFKA8iuw53xHzug9ipr6MuHq";
         assert_eq!(expected, decoded);
 
@@ -286,7 +455,7 @@ mod tests {
     #[test]
     fn test_encode_contract_tz2() -> Result<(), failure::Error> {
         let decoded = HashType::ContractTz2Hash
-            .hash_to_b58check(&hex::decode("2fcb1d9307f0b1f94c048ff586c09f46614c7e90")?);
+            .hash_to_b58check(&hex::decode("2fcb1d9307f0b1f94c048ff586c09f46614c7e90")?)?;
         let expected = "tz2Cfwk4ortcaqAGcVJKSxLiAdcFxXBLBoyY";
         assert_eq!(expected, decoded);
 
@@ -296,7 +465,7 @@ mod tests {
     #[test]
     fn test_encode_contract_tz3() -> Result<(), failure::Error> {
         let decoded = HashType::ContractTz3Hash
-            .hash_to_b58check(&hex::decode("193b2b3f6b8f8e1e6b39b4d442fc2b432f6427a8")?);
+            .hash_to_b58check(&hex::decode("193b2b3f6b8f8e1e6b39b4d442fc2b432f6427a8")?)?;
         let expected = "tz3NdTPb3Ax2rVW2Kq9QEdzfYFkRwhrQRPhX";
         assert_eq!(expected, decoded);
 
@@ -306,7 +475,7 @@ mod tests {
     #[test]
     fn test_encode_contract_kt1() -> Result<(), failure::Error> {
         let decoded = HashType::ContractKt1Hash
-            .hash_to_b58check(&hex::decode("42b419240509ddacd12839700b7f720b4aa55e4e")?);
+            .hash_to_b58check(&hex::decode("42b419240509ddacd12839700b7f720b4aa55e4e")?)?;
         let expected = "KT1EfTusMLoeCAAGd9MZJn5yKzFr6kJU5U91";
         assert_eq!(expected, decoded);
 
@@ -337,15 +506,15 @@ mod tests {
 
     #[test]
     fn test_decode_protocol_hash() -> Result<(), failure::Error> {
-        let decoded = HashType::ProtocolHash
-            .b58check_to_hash("PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb")?;
-        let decoded = hex::encode(&decoded);
+        let decoded = ProtocolHash
+            ::from_base58_check("PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb")?;
+        let decoded = hex::encode(decoded.as_ref());
         let expected = "3e5e3a606afab74a59ca09e333633e2770b6492c5e594455b71e9a2f0ea92afb";
         assert_eq!(expected, decoded);
 
         assert_eq!(
             "PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb",
-            HashType::ProtocolHash.hash_to_b58check(&hex::decode(decoded)?)
+            HashType::ProtocolHash.hash_to_b58check(&hex::decode(decoded)?)?
         );
         Ok(())
     }
@@ -360,7 +529,7 @@ mod tests {
 
         assert_eq!(
             "bm2gU1qwmoPNsXzFKydPDHWX37es6C5Z4nHyuesW8YxbkZ1339cN",
-            HashType::BlockMetadataHash.hash_to_b58check(&hex::decode(decoded)?)
+            HashType::BlockMetadataHash.hash_to_b58check(&hex::decode(decoded)?)?
         );
         Ok(())
     }
@@ -375,7 +544,7 @@ mod tests {
 
         assert_eq!(
             "LLr283rR7AWhepNeHcP9msa2VeAurWtodBLrnSjwaxpNyiyfhYcKX",
-            HashType::OperationMetadataListListHash.hash_to_b58check(&hex::decode(decoded)?)
+            HashType::OperationMetadataListListHash.hash_to_b58check(&hex::decode(decoded)?)?
         );
         Ok(())
     }
@@ -390,7 +559,7 @@ mod tests {
 
         assert_eq!(
             "r3E9xb2QxUeG56eujC66B56CV8mpwjwfdVmEpYu3FRtuEx9tyfG",
-            HashType::OperationMetadataHash.hash_to_b58check(&hex::decode(decoded)?)
+            HashType::OperationMetadataHash.hash_to_b58check(&hex::decode(decoded)?)?
         );
         Ok(())
     }

--- a/crypto/src/seeded_step.rs
+++ b/crypto/src/seeded_step.rs
@@ -431,9 +431,12 @@ mod tests {
     }
 
     fn generate_key_string(c: char) -> CryptoboxPublicKeyHash {
-        CryptoboxPublicKeyHash::try_from(std::iter::repeat(c)
-            .take(HashType::CryptoboxPublicKeyHash.size())
-            .collect::<String>()
-            .into_bytes()).unwrap()
+        CryptoboxPublicKeyHash::try_from(
+            std::iter::repeat(c)
+                .take(HashType::CryptoboxPublicKeyHash.size())
+                .collect::<String>()
+                .into_bytes(),
+        )
+        .unwrap()
     }
 }

--- a/crypto/src/seeded_step.rs
+++ b/crypto/src/seeded_step.rs
@@ -35,9 +35,9 @@ pub struct Step {
 impl Step {
     pub fn init(seed: &Seed, block_hash: &BlockHash) -> Step {
         let mut hash_state = sha256::State::new();
-        hash_state.update(&seed.sender_id);
-        hash_state.update(&seed.receiver_id);
-        hash_state.update(&block_hash);
+        hash_state.update(seed.sender_id.as_ref());
+        hash_state.update(seed.receiver_id.as_ref());
+        hash_state.update(block_hash.as_ref());
         let Digest(h) = hash_state.finalize();
         Step {
             step: 1,
@@ -90,6 +90,8 @@ impl Step {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::{TryFrom, TryInto};
+
     use crate::hash::{CryptoboxPublicKeyHash, HashType};
     use crate::seeded_step::{Seed, Step};
 
@@ -97,8 +99,7 @@ mod tests {
     pub fn test_step_init() -> Result<(), failure::Error> {
         let step = Step::init(
             &Seed::new(&generate_key_string('s'), &generate_key_string('r')),
-            &HashType::BlockHash
-                .b58check_to_hash("BLrJE6yTjLLuEYgyqLxDBduEuA5S1uCkiq499tCK81TLoqTbNmm")?,
+            &"BLrJE6yTjLLuEYgyqLxDBduEuA5S1uCkiq499tCK81TLoqTbNmm".try_into()?,
         );
         assert_step_state(
             &step,
@@ -114,8 +115,7 @@ mod tests {
     pub fn test_step_next() -> Result<(), failure::Error> {
         let mut step = Step::init(
             &Seed::new(&generate_key_string('s'), &generate_key_string('r')),
-            &HashType::BlockHash
-                .b58check_to_hash("BLrJE6yTjLLuEYgyqLxDBduEuA5S1uCkiq499tCK81TLoqTbNmm")?,
+            &"BLrJE6yTjLLuEYgyqLxDBduEuA5S1uCkiq499tCK81TLoqTbNmm".try_into()?,
         );
         assert_step_state(
             &step,
@@ -431,9 +431,9 @@ mod tests {
     }
 
     fn generate_key_string(c: char) -> CryptoboxPublicKeyHash {
-        std::iter::repeat(c)
+        CryptoboxPublicKeyHash::try_from(std::iter::repeat(c)
             .take(HashType::CryptoboxPublicKeyHash.size())
             .collect::<String>()
-            .into_bytes()
+            .into_bytes()).unwrap()
     }
 }

--- a/monitoring/src/monitors/block_application_monitor.rs
+++ b/monitoring/src/monitors/block_application_monitor.rs
@@ -3,7 +3,6 @@
 
 use std::time::Instant;
 
-use crypto::hash::HashType;
 use tezos_messages::Head;
 
 use crate::handlers::handler_messages::{BlockApplicationMessage, BlockInfo};
@@ -45,7 +44,7 @@ impl ApplicationMonitor {
     pub fn snapshot(&mut self) -> BlockApplicationMessage {
         let last_block = if let Some(block) = &self.last_applied_block {
             Some(BlockInfo {
-                hash: HashType::BlockHash.hash_to_b58check(block.block_hash()),
+                hash: block.block_hash().to_base58_check(),
                 level: *block.level(),
             })
         } else {

--- a/networking/src/p2p/peer.rs
+++ b/networking/src/p2p/peer.rs
@@ -16,7 +16,7 @@ use tokio::runtime::Handle;
 use tokio::time::timeout;
 
 use crypto::crypto_box::{CryptoKey, PrecomputedKey, PublicKey};
-use crypto::hash::{CryptoboxPublicKeyHash, HashType};
+use crypto::hash::CryptoboxPublicKeyHash;
 use crypto::nonce::{self, Nonce, NoncePair};
 use tezos_encoding::binary_reader::BinaryReaderError;
 use tezos_identity::Identity;
@@ -393,7 +393,7 @@ pub async fn bootstrap(
 
     // generate public key hash for PublicKey, which will be used as a peer_id
     let peer_public_key_hash = peer_public_key.public_key_hash();
-    let peer_id_marker = HashType::CryptoboxPublicKeyHash.hash_to_b58check(&peer_public_key_hash);
+    let peer_id_marker = peer_public_key_hash.to_base58_check();
     let log = log.new(o!("peer_id" => peer_id_marker.clone()));
 
     // from now on all messages will be encrypted

--- a/networking/src/p2p/peer.rs
+++ b/networking/src/p2p/peer.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use failure::{Error, Fail};
 use futures::lock::Mutex;
 use riker::actors::*;
-use slog::{debug, info, Logger, o, trace, warn};
+use slog::{debug, info, o, trace, warn, Logger};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 use tokio::runtime::Handle;
@@ -24,10 +24,12 @@ use tezos_messages::p2p::binary_message::{BinaryChunk, BinaryChunkError, BinaryM
 use tezos_messages::p2p::encoding::ack::{NackInfo, NackMotive};
 use tezos_messages::p2p::encoding::prelude::*;
 
-use crate::{PeerId, ShellCompatibilityVersion};
 use crate::p2p::network_channel::NetworkChannelMsg;
+use crate::{PeerId, ShellCompatibilityVersion};
 
-use super::network_channel::{NetworkChannelRef, NetworkChannelTopic, PeerBootstrapFailed, PeerMessageReceived};
+use super::network_channel::{
+    NetworkChannelRef, NetworkChannelTopic, PeerBootstrapFailed, PeerMessageReceived,
+};
 use super::stream::{EncryptedMessageReader, EncryptedMessageWriter, MessageStream, StreamError};
 
 const IO_TIMEOUT: Duration = Duration::from_secs(6);
@@ -38,7 +40,10 @@ static ACTOR_ID_GENERATOR: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Fail)]
 pub enum PeerError {
-    #[fail(display = "Unsupported protocol - shell: ({}) is not compatible with peer: ({})", supported_version, incompatible_version)]
+    #[fail(
+        display = "Unsupported protocol - shell: ({}) is not compatible with peer: ({})",
+        supported_version, incompatible_version
+    )]
     UnsupportedProtocol {
         supported_version: String,
         incompatible_version: String,
@@ -46,26 +51,15 @@ pub enum PeerError {
     #[fail(display = "Received NACK from remote peer")]
     NackReceived,
     #[fail(display = "Received NACK from remote peer with info: {:?}", nack_info)]
-    NackWithMotiveReceived {
-        nack_info: NackInfo
-    },
+    NackWithMotiveReceived { nack_info: NackInfo },
     #[fail(display = "Network error: {}, reason: {}", message, error)]
-    NetworkError {
-        error: Error,
-        message: &'static str,
-    },
+    NetworkError { error: Error, message: &'static str },
     #[fail(display = "Message serialization error, reason: {}", error)]
-    SerializationError {
-        error: tezos_encoding::ser::Error
-    },
+    SerializationError { error: tezos_encoding::ser::Error },
     #[fail(display = "Message deserialization error, reason: {}", error)]
-    DeserializationError {
-        error: BinaryReaderError
-    },
+    DeserializationError { error: BinaryReaderError },
     #[fail(display = "Crypto error, reason: {}", error)]
-    CryptoError {
-        error: crypto::CryptoError
-    },
+    CryptoError { error: crypto::CryptoError },
 }
 
 impl From<tezos_encoding::ser::Error> for PeerError {
@@ -82,19 +76,28 @@ impl From<BinaryReaderError> for PeerError {
 
 impl From<std::io::Error> for PeerError {
     fn from(error: std::io::Error) -> Self {
-        PeerError::NetworkError { error: error.into(), message: "Network error" }
+        PeerError::NetworkError {
+            error: error.into(),
+            message: "Network error",
+        }
     }
 }
 
 impl From<StreamError> for PeerError {
     fn from(error: StreamError) -> Self {
-        PeerError::NetworkError { error: error.into(), message: "Stream error" }
+        PeerError::NetworkError {
+            error: error.into(),
+            message: "Stream error",
+        }
     }
 }
 
 impl From<BinaryChunkError> for PeerError {
     fn from(error: BinaryChunkError) -> Self {
-        PeerError::NetworkError { error: error.into(), message: "Binary chunk error" }
+        PeerError::NetworkError {
+            error: error.into(),
+            message: "Binary chunk error",
+        }
     }
 }
 
@@ -124,12 +127,34 @@ pub struct Bootstrap {
 }
 
 impl Bootstrap {
-    pub fn incoming(stream: Arc<Mutex<Option<TcpStream>>>, address: SocketAddr, disable_mempool: bool, private_node: bool) -> Self {
-        Bootstrap { stream, address, incoming: true, disable_mempool, private_node }
+    pub fn incoming(
+        stream: Arc<Mutex<Option<TcpStream>>>,
+        address: SocketAddr,
+        disable_mempool: bool,
+        private_node: bool,
+    ) -> Self {
+        Bootstrap {
+            stream,
+            address,
+            incoming: true,
+            disable_mempool,
+            private_node,
+        }
     }
 
-    pub fn outgoing(stream: TcpStream, address: SocketAddr, disable_mempool: bool, private_node: bool) -> Self {
-        Bootstrap { stream: Arc::new(Mutex::new(Some(stream))), address, incoming: false, disable_mempool, private_node }
+    pub fn outgoing(
+        stream: TcpStream,
+        address: SocketAddr,
+        disable_mempool: bool,
+        private_node: bool,
+    ) -> Self {
+        Bootstrap {
+            stream: Arc::new(Mutex::new(Some(stream))),
+            address,
+            incoming: false,
+            disable_mempool,
+            private_node,
+        }
     }
 }
 
@@ -137,7 +162,7 @@ impl Bootstrap {
 #[derive(Clone, Debug)]
 pub struct SendMessage {
     /// Message is wrapped in `Arc` to avoid excessive cloning.
-    message: Arc<PeerMessageResponse>
+    message: Arc<PeerMessageResponse>,
 }
 
 impl SendMessage {
@@ -168,7 +193,11 @@ pub struct Local {
 }
 
 impl Local {
-    pub fn new(listener_port: u16, identity: Arc<Identity>, version: Arc<ShellCompatibilityVersion>) -> Self {
+    pub fn new(
+        listener_port: u16,
+        identity: Arc<Identity>,
+        version: Arc<ShellCompatibilityVersion>,
+    ) -> Self {
         Local {
             listener_port,
             identity,
@@ -196,23 +225,36 @@ pub struct Peer {
 
 impl Peer {
     /// Create instance of a peer actor.
-    pub fn actor(sys: &impl ActorRefFactory,
-                 network_channel: NetworkChannelRef,
-                 listener_port: u16,
-                 node_identity: Arc<Identity>,
-                 version: Arc<ShellCompatibilityVersion>,
-                 tokio_executor: Handle,
-                 socket_address: &SocketAddr) -> Result<PeerRef, CreateError>
-    {
+    pub fn actor(
+        sys: &impl ActorRefFactory,
+        network_channel: NetworkChannelRef,
+        listener_port: u16,
+        node_identity: Arc<Identity>,
+        version: Arc<ShellCompatibilityVersion>,
+        tokio_executor: Handle,
+        socket_address: &SocketAddr,
+    ) -> Result<PeerRef, CreateError> {
         let info = Local::new(listener_port, node_identity, version);
-        let props = Props::new_args::<Peer, _>((network_channel, Arc::new(info), tokio_executor, *socket_address));
+        let props = Props::new_args::<Peer, _>((
+            network_channel,
+            Arc::new(info),
+            tokio_executor,
+            *socket_address,
+        ));
         let actor_id = ACTOR_ID_GENERATOR.fetch_add(1, Ordering::SeqCst);
         sys.actor_of_props(&format!("peer-{}", actor_id), props)
     }
 }
 
 impl ActorFactoryArgs<(NetworkChannelRef, Arc<Local>, Handle, SocketAddr)> for Peer {
-    fn create_args((event_channel, info, tokio_executor, socket_address): (NetworkChannelRef, Arc<Local>, Handle, SocketAddr)) -> Self {
+    fn create_args(
+        (event_channel, info, tokio_executor, socket_address): (
+            NetworkChannelRef,
+            Arc<Local>,
+            Handle,
+            SocketAddr,
+        ),
+    ) -> Self {
         Peer {
             network_channel: event_channel,
             local: info,
@@ -321,7 +363,8 @@ impl Receive<SendMessage> for Peer {
         self.tokio_executor.spawn(async move {
             let mut tx_lock = tx.lock().await;
             if let Some(tx) = tx_lock.as_mut() {
-                let write_result = timeout(IO_TIMEOUT, tx.write_message(msg.message.as_ref())).await;
+                let write_result =
+                    timeout(IO_TIMEOUT, tx.write_message(msg.message.as_ref())).await;
                 // release mutex as soon as possible
                 drop(tx_lock);
 
@@ -343,7 +386,14 @@ impl Receive<SendMessage> for Peer {
 }
 
 /// Output values of the successful bootstrap process
-pub struct BootstrapOutput(pub EncryptedMessageReader, pub EncryptedMessageWriter, pub CryptoboxPublicKeyHash, pub String, pub MetadataMessage, pub NetworkVersion);
+pub struct BootstrapOutput(
+    pub EncryptedMessageReader,
+    pub EncryptedMessageWriter,
+    pub CryptoboxPublicKeyHash,
+    pub String,
+    pub MetadataMessage,
+    pub NetworkVersion,
+);
 
 pub async fn bootstrap(
     msg: Bootstrap,
@@ -351,7 +401,12 @@ pub async fn bootstrap(
     log: &Logger,
 ) -> Result<BootstrapOutput, PeerError> {
     let (mut msg_rx, mut msg_tx) = {
-        let stream = msg.stream.lock().await.take().expect("Someone took ownership of the socket before the Peer");
+        let stream = msg
+            .stream
+            .lock()
+            .await
+            .take()
+            .expect("Someone took ownership of the socket before the Peer");
         let msg_reader: MessageStream = stream.into();
         msg_reader.split()
     };
@@ -370,20 +425,39 @@ pub async fn bootstrap(
         let connection_message_bytes = BinaryChunk::from_content(&connection_message.as_bytes()?)?;
         match timeout(IO_TIMEOUT, msg_tx.write_message(&connection_message_bytes)).await? {
             Ok(_) => connection_message_bytes,
-            Err(e) => return Err(PeerError::NetworkError { error: e.into(), message: "Failed to transfer connection message" })
+            Err(e) => {
+                return Err(PeerError::NetworkError {
+                    error: e.into(),
+                    message: "Failed to transfer connection message",
+                })
+            }
         }
     };
 
     // receive connection message
-    let received_connection_message_bytes = match timeout(IO_TIMEOUT, msg_rx.read_message()).await? {
+    let received_connection_message_bytes = match timeout(IO_TIMEOUT, msg_rx.read_message()).await?
+    {
         Ok(msg) => msg,
-        Err(e) => return Err(PeerError::NetworkError { error: e.into(), message: "No response to connection message was received" })
+        Err(e) => {
+            return Err(PeerError::NetworkError {
+                error: e.into(),
+                message: "No response to connection message was received",
+            })
+        }
     };
 
-    let connection_message = ConnectionMessage::from_bytes(received_connection_message_bytes.content())?;
+    let connection_message =
+        ConnectionMessage::from_bytes(received_connection_message_bytes.content())?;
 
     // generate local and remote nonce
-    let NoncePair { local: nonce_local, remote: nonce_remote } = generate_nonces(&connection_message_sent, &received_connection_message_bytes, msg.incoming);
+    let NoncePair {
+        local: nonce_local,
+        remote: nonce_remote,
+    } = generate_nonces(
+        &connection_message_sent,
+        &received_connection_message_bytes,
+        msg.incoming,
+    );
 
     // create PublicKey from received bytes from remote peer
     let peer_public_key = PublicKey::from_bytes(connection_message.public_key())?;
@@ -397,24 +471,18 @@ pub async fn bootstrap(
     let log = log.new(o!("peer_id" => peer_id_marker.clone()));
 
     // from now on all messages will be encrypted
-    let mut msg_tx = EncryptedMessageWriter::new(
-        msg_tx,
-        precomputed_key.clone(),
-        nonce_local,
-        log.clone(),
-    );
-    let mut msg_rx = EncryptedMessageReader::new(
-        msg_rx,
-        precomputed_key,
-        nonce_remote,
-        log.clone(),
-    );
+    let mut msg_tx =
+        EncryptedMessageWriter::new(msg_tx, precomputed_key.clone(), nonce_local, log.clone());
+    let mut msg_rx =
+        EncryptedMessageReader::new(msg_rx, precomputed_key, nonce_remote, log.clone());
 
     let connecting_to_self = peer_public_key == info.identity.public_key;
     if connecting_to_self {
         debug!(log, "Detected self connection");
         // treat as if nack was received
-        return Err(PeerError::NackWithMotiveReceived { nack_info: NackInfo::new(NackMotive::AlreadyConnected, &[]) });
+        return Err(PeerError::NackWithMotiveReceived {
+            nack_info: NackInfo::new(NackMotive::AlreadyConnected, &[]),
+        });
     }
 
     // send metadata
@@ -425,30 +493,40 @@ pub async fn bootstrap(
     let metadata_received = timeout(IO_TIMEOUT, msg_rx.read_message::<MetadataMessage>()).await??;
     debug!(log, "Received remote peer metadata"; "disable_mempool" => metadata_received.disable_mempool(), "private_node" => metadata_received.private_node());
 
-    let compatible_network_version = match supported_protocol_version.choose_compatible_version(connection_message.version()) {
-        Ok(compatible_version) => compatible_version,
-        Err(nack_motive) => {
-            // send nack
-            if connection_message.version().supports_nack_with_list_and_motive() {
-                timeout(IO_TIMEOUT, msg_tx.write_message(&AckMessage::Nack(NackInfo::new(nack_motive, &[])))).await??;
-            } else {
-                timeout(IO_TIMEOUT, msg_tx.write_message(&AckMessage::NackV0)).await??;
-            }
+    let compatible_network_version =
+        match supported_protocol_version.choose_compatible_version(connection_message.version()) {
+            Ok(compatible_version) => compatible_version,
+            Err(nack_motive) => {
+                // send nack
+                if connection_message
+                    .version()
+                    .supports_nack_with_list_and_motive()
+                {
+                    timeout(
+                        IO_TIMEOUT,
+                        msg_tx.write_message(&AckMessage::Nack(NackInfo::new(nack_motive, &[]))),
+                    )
+                    .await??;
+                } else {
+                    timeout(IO_TIMEOUT, msg_tx.write_message(&AckMessage::NackV0)).await??;
+                }
 
-            return Err(
-                PeerError::UnsupportedProtocol {
+                return Err(PeerError::UnsupportedProtocol {
                     supported_version: format!(
                         "{}/distributed_db_versions {:?}/p2p_versions {:?}",
-                        supported_protocol_version.version.chain_name(), supported_protocol_version.distributed_db_versions, supported_protocol_version.p2p_versions
+                        supported_protocol_version.version.chain_name(),
+                        supported_protocol_version.distributed_db_versions,
+                        supported_protocol_version.p2p_versions
                     ),
                     incompatible_version: format!(
                         "{}/distributed_db_version {}/p2p_version {}",
-                        connection_message.version().chain_name(), connection_message.version().distributed_db_version(), connection_message.version().p2p_version()
+                        connection_message.version().chain_name(),
+                        connection_message.version().distributed_db_version(),
+                        connection_message.version().p2p_version()
                     ),
-                }
-            );
-        }
-    };
+                });
+            }
+        };
 
     // send ack
     timeout(IO_TIMEOUT, msg_tx.write_message(&AckMessage::Ack)).await??;
@@ -459,7 +537,14 @@ pub async fn bootstrap(
     match ack_received {
         AckMessage::Ack => {
             debug!(log, "Received ACK");
-            Ok(BootstrapOutput(msg_rx, msg_tx, peer_public_key_hash, peer_id_marker, metadata_received, compatible_network_version))
+            Ok(BootstrapOutput(
+                msg_rx,
+                msg_tx,
+                peer_public_key_hash,
+                peer_id_marker,
+                metadata_received,
+                compatible_network_version,
+            ))
         }
         AckMessage::NackV0 => {
             debug!(log, "Received NACK");
@@ -472,7 +557,6 @@ pub async fn bootstrap(
     }
 }
 
-
 /// Generate nonces (sent and recv encoding must be with length bytes also)
 ///
 /// local_nonce is used for writing crypto messages to other peers
@@ -482,7 +566,13 @@ fn generate_nonces(sent_msg: &BinaryChunk, recv_msg: &BinaryChunk, incoming: boo
 }
 
 /// Start to process incoming data
-async fn begin_process_incoming(mut rx: EncryptedMessageReader, net: Network, myself: PeerRef, event_channel: NetworkChannelRef, log: Logger) {
+async fn begin_process_incoming(
+    mut rx: EncryptedMessageReader,
+    net: Network,
+    myself: PeerRef,
+    event_channel: NetworkChannelRef,
+    log: Logger,
+) {
     info!(log, "Starting to accept messages");
 
     while net.rx_run.load(Ordering::Acquire) {
@@ -497,20 +587,26 @@ async fn begin_process_incoming(mut rx: EncryptedMessageReader, net: Network, my
                                 msg: PeerMessageReceived {
                                     peer: myself.clone(),
                                     message: Arc::new(msg),
-                                }.into(),
+                                }
+                                .into(),
                                 topic: NetworkChannelTopic::NetworkEvents.into(),
-                            }, Some(myself.clone().into()));
+                            },
+                            Some(myself.clone().into()),
+                        );
                     }
                 }
                 Err(e) => {
-                    if let StreamError::DeserializationError { error: BinaryReaderError::UnsupportedTag { tag } } = e {
+                    if let StreamError::DeserializationError {
+                        error: BinaryReaderError::UnsupportedTag { tag },
+                    } = e
+                    {
                         warn!(log, "Messages with unsupported tags are ignored"; "tag" => tag);
                     } else {
                         warn!(log, "Failed to read peer message"; "reason" => e);
                         break;
                     }
                 }
-            }
+            },
             Err(_) => {
                 warn!(log, "Peer message read timed out"; "secs" => READ_TIMEOUT_LONG.as_secs());
                 break;
@@ -523,8 +619,12 @@ async fn begin_process_incoming(mut rx: EncryptedMessageReader, net: Network, my
     if let Some(tx) = tx_lock.take() {
         let mut socket = rx.unsplit(tx);
         match socket.shutdown().await {
-            Ok(()) => debug!(log, "Connection shutdown successful"; "socket" => format!("{:?}", socket)),
-            Err(err) => debug!(log, "Failed to shutdown connection"; "err" => format!("{:?}", err), "socket" => format!("{:?}", socket)),
+            Ok(()) => {
+                debug!(log, "Connection shutdown successful"; "socket" => format!("{:?}", socket))
+            }
+            Err(err) => {
+                debug!(log, "Failed to shutdown connection"; "err" => format!("{:?}", err), "socket" => format!("{:?}", socket))
+            }
         }
     }
 

--- a/rpc/src/encoding/monitor.rs
+++ b/rpc/src/encoding/monitor.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crypto::hash::{BlockHash, HashType};
+use crypto::hash::BlockHash;
 use tezos_messages::p2p::encoding::prelude::*;
 
 use super::base_types::*;
@@ -70,7 +70,7 @@ pub struct BootstrapInfo {
 impl BootstrapInfo {
     pub fn new(block: &BlockHash, timestamp: TimeStamp) -> Self {
         Self {
-            block: HashType::BlockHash.hash_to_b58check(block),
+            block: block.to_base58_check(),
             timestamp,
         }
     }

--- a/rpc/src/helpers.rs
+++ b/rpc/src/helpers.rs
@@ -1,7 +1,7 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::ops::Neg;
+use std::{convert::TryInto, ops::Neg};
 use std::{collections::HashMap, convert::TryFrom};
 
 use failure::{bail, format_err};
@@ -10,7 +10,7 @@ use riker::actor::ActorReference;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crypto::hash::{chain_id_to_b58_string, BlockHash, ChainId, ContextHash, HashType};
+use crypto::hash::{chain_id_to_b58_string, BlockHash, ChainId, ContextHash};
 use shell::mempool::mempool_prevalidator::MempoolPrevalidator;
 use storage::chain_meta_storage::ChainMetaStorageReader;
 use storage::context_action_storage::ContextActionType;
@@ -128,13 +128,12 @@ impl FullBlockInfo {
         chain_id: &ChainId,
     ) -> Self {
         let header: &BlockHeader = &block.header;
-        let predecessor = HashType::BlockHash.hash_to_b58check(header.predecessor());
+        let predecessor = header.predecessor().to_base58_check();
         let timestamp = ts_to_rfc3339(header.timestamp());
-        let operations_hash =
-            HashType::OperationListListHash.hash_to_b58check(header.operations_hash());
+        let operations_hash = header.operations_hash().to_base58_check();
         let fitness = header.fitness().iter().map(|x| hex::encode(&x)).collect();
-        let context = HashType::ContextHash.hash_to_b58check(header.context());
-        let hash = HashType::BlockHash.hash_to_b58check(&block.hash);
+        let context = header.context().to_base58_check();
+        let hash = block.hash.to_base58_check();
 
         Self {
             hash,
@@ -166,13 +165,12 @@ impl BlockHeaderInfo {
         chain_id: &ChainId,
     ) -> Self {
         let header: &BlockHeader = &block.header;
-        let predecessor = HashType::BlockHash.hash_to_b58check(header.predecessor());
+        let predecessor = header.predecessor().to_base58_check();
         let timestamp = ts_to_rfc3339(header.timestamp());
-        let operations_hash =
-            HashType::OperationListListHash.hash_to_b58check(header.operations_hash());
+        let operations_hash = header.operations_hash().to_base58_check();
         let fitness = header.fitness().iter().map(|x| hex::encode(&x)).collect();
-        let context = HashType::ContextHash.hash_to_b58check(header.context());
-        let hash = HashType::BlockHash.hash_to_b58check(&block.hash);
+        let context = header.context().to_base58_check();
+        let hash = block.hash.to_base58_check();
 
         let header_data: HashMap<String, Value> =
             serde_json::from_str(block_json_data.block_header_proto_json()).unwrap_or_default();
@@ -369,24 +367,24 @@ pub(crate) fn parse_chain_id(
                 Some(test_chain_id) => test_chain_id,
                 None => bail!(
                     "No test chain activated for main_chain_id: {}",
-                    HashType::ChainId.hash_to_b58check(env.main_chain_id())
+                    env.main_chain_id().to_base58_check()
                 ),
             };
 
             bail!(
                 "Test chains are not supported yet! main_chain_id: {}, test_chain_id: {}",
-                HashType::ChainId.hash_to_b58check(env.main_chain_id()),
-                HashType::ChainId.hash_to_b58check(&test_chain)
+                env.main_chain_id().to_base58_check(),
+                test_chain.to_base58_check()
             )
         }
         chain_id_hash => {
-            let chain_id = HashType::ChainId.b58check_to_hash(chain_id_hash)?;
+            let chain_id: ChainId = chain_id_hash.try_into()?;
             if chain_id.eq(env.main_chain_id()) {
                 chain_id
             } else {
                 bail!("Multiple chains are not supported yet! requested_chain_id: {} only main_chain_id: {}",
-                        HashType::ChainId.hash_to_b58check(&chain_id),
-                        HashType::ChainId.hash_to_b58check(env.main_chain_id()))
+                        chain_id.to_base58_check(),
+                        env.main_chain_id().to_base58_check())
             }
         }
     })
@@ -483,7 +481,7 @@ pub(crate) fn parse_block_hash(
                 }
                 None => bail!(
                     "No genesis found for chain_id: {}",
-                    HashType::ChainId.hash_to_b58check(chain_id)
+                    chain_id.to_base58_check()
                 ),
             }
         }
@@ -506,7 +504,7 @@ pub(crate) fn parse_block_hash(
                 }
                 Err(_) => {
                     // block hash as base58 string was passed as parameter to block_id
-                    match HashType::BlockHash.b58check_to_hash(level_or_hash) {
+                    match BlockHash::from_base58_check(level_or_hash) {
                         Ok(block_hash) => (block_hash, offset_param),
                         Err(e) => {
                             bail!("Invalid block_id_param: {}, reason: {}", block_id_param, e)
@@ -551,7 +549,7 @@ pub(crate) fn get_context_hash(
         Some(header) => Ok(header.header.context().clone()),
         None => bail!(
             "Block not found for block_hash: {}",
-            HashType::BlockHash.hash_to_b58check(block_hash)
+            block_hash.to_base58_check()
         ),
     }
 }

--- a/rpc/src/helpers.rs
+++ b/rpc/src/helpers.rs
@@ -1,8 +1,8 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::{convert::TryInto, ops::Neg};
 use std::{collections::HashMap, convert::TryFrom};
+use std::{convert::TryInto, ops::Neg};
 
 use failure::{bail, format_err};
 use hyper::{Body, Request};

--- a/rpc/src/server/shell_handler.rs
+++ b/rpc/src/server/shell_handler.rs
@@ -9,7 +9,7 @@ use hyper::body::Buf;
 use hyper::{Body, Method, Request};
 use serde::Serialize;
 
-use crypto::hash::{ProtocolHash, chain_id_to_b58_string};
+use crypto::hash::{chain_id_to_b58_string, ProtocolHash};
 use tezos_api::ffi::ProtocolRpcError;
 use tezos_messages::ts_to_rfc3339;
 use tezos_wrapper::service::{ProtocolError, ProtocolServiceError};
@@ -369,10 +369,7 @@ pub async fn get_block_hash(
     let chain_id = parse_chain_id(required_param!(params, "chain_id")?, &env)?;
     let block_hash = parse_block_hash(&chain_id, required_param!(params, "block_id")?, &env)?;
 
-    result_to_json_response(
-        Ok(block_hash.to_base58_check()),
-        env.log(),
-    )
+    result_to_json_response(Ok(block_hash.to_base58_check()), env.log())
 }
 
 pub async fn get_chain_id(

--- a/rpc/src/server/shell_handler.rs
+++ b/rpc/src/server/shell_handler.rs
@@ -9,7 +9,7 @@ use hyper::body::Buf;
 use hyper::{Body, Method, Request};
 use serde::Serialize;
 
-use crypto::hash::{chain_id_to_b58_string, HashType};
+use crypto::hash::{ProtocolHash, chain_id_to_b58_string};
 use tezos_api::ffi::ProtocolRpcError;
 use tezos_messages::ts_to_rfc3339;
 use tezos_wrapper::service::{ProtocolError, ProtocolServiceError};
@@ -97,7 +97,7 @@ pub async fn head_chain(
 ) -> ServiceResult {
     let chain_id = parse_chain_id(required_param!(params, "chain_id")?, &env)?;
     let protocol = if let Some(protocol) = query.get_str("next_protocol") {
-        HashType::ProtocolHash.b58check_to_hash(protocol).ok()
+        ProtocolHash::from_base58_check(protocol).ok()
     } else {
         None
     };
@@ -370,7 +370,7 @@ pub async fn get_block_hash(
     let block_hash = parse_block_hash(&chain_id, required_param!(params, "block_id")?, &env)?;
 
     result_to_json_response(
-        Ok(HashType::BlockHash.hash_to_b58check(&block_hash)),
+        Ok(block_hash.to_base58_check()),
         env.log(),
     )
 }

--- a/rpc/src/services/base_services.rs
+++ b/rpc/src/services/base_services.rs
@@ -3,7 +3,7 @@
 
 use failure::bail;
 
-use crypto::hash::{BlockHash, ChainId, HashType};
+use crypto::hash::{BlockHash, ChainId};
 use storage::block_storage::BlockJsonData;
 use storage::context::ContextApi;
 use storage::merkle_storage::StringTreeEntry;
@@ -99,7 +99,7 @@ pub(crate) fn live_blocks(
         Some((_, json_data)) => json_data.max_operations_ttl().into(),
         None => bail!(
             "Max_ttl not found for block id: {}",
-            HashType::BlockHash.hash_to_b58check(&block_hash)
+            block_hash.to_base58_check()
         ),
     };
 
@@ -107,7 +107,7 @@ pub(crate) fn live_blocks(
     let live_blocks = block_meta_storage
         .get_live_blocks(block_hash, max_ttl)?
         .iter()
-        .map(|block| HashType::BlockHash.hash_to_b58check(&block))
+        .map(|block| block.to_base58_check())
         .collect();
 
     Ok(live_blocks)
@@ -152,7 +152,7 @@ pub(crate) fn get_block_protocols(
     } else {
         bail!(
             "Cannot retrieve protocols, block_hash {} not found!",
-            HashType::BlockHash.hash_to_b58check(block_hash)
+            block_hash.to_base58_check()
         )
     }
 }
@@ -178,7 +178,7 @@ pub(crate) fn get_block_operation_hashes(
     } else {
         bail!(
             "Cannot retrieve operation hashes from block, block_hash {} not found!",
-            HashType::BlockHash.hash_to_b58check(block_hash)
+            block_hash.to_base58_check()
         )
     }
 }

--- a/rpc/src/services/dev_services.rs
+++ b/rpc/src/services/dev_services.rs
@@ -3,7 +3,7 @@
 
 use slog::Logger;
 
-use crypto::hash::{BlockHash, HashType};
+use crypto::hash::BlockHash;
 use shell::stats::memory::{Memory, MemoryData, MemoryStatsResult};
 use storage::context::{ContextApi, TezedgeContext};
 use storage::context_action_storage::{
@@ -48,7 +48,7 @@ pub(crate) fn get_block_actions_cursor(
     persistent_storage: &PersistentStorage,
 ) -> Result<Vec<ContextActionJson>, failure::Error> {
     let context_action_storage = ContextActionStorage::new(persistent_storage);
-    let mut filters = ContextActionFilters::with_block_hash(block_hash);
+    let mut filters = ContextActionFilters::with_block_hash(block_hash.into());
     if let Some(action_types) = action_types {
         filters = filters.with_action_types(get_action_types(action_types));
     }
@@ -125,15 +125,15 @@ pub(crate) fn get_cycle_length_for_block(
         )?
             .map(|constants| constants.get("blocks_per_cycle")
                 .map(|value| if let UniversalValue::Number(value) = value { *value } else {
-                    slog::warn!(log, "Cycle length missing"; "block" => HashType::BlockHash.hash_to_b58check(block_hash));
+                    slog::warn!(log, "Cycle length missing"; "block" => block_hash.to_base58_check());
                     4096
                 })
             ).flatten().unwrap_or_else(|| {
-            slog::warn!(log, "Cycle length missing"; "block" => HashType::BlockHash.hash_to_b58check(block_hash));
+            slog::warn!(log, "Cycle length missing"; "block" => block_hash.to_base58_check());
             4096
         }))
     } else {
-        slog::warn!(log, "Cycle length missing"; "block" => HashType::BlockHash.hash_to_b58check(block_hash));
+        slog::warn!(log, "Cycle length missing"; "block" => block_hash.to_base58_check());
         Ok(4096)
     }
 }

--- a/rpc/src/services/mempool_services.rs
+++ b/rpc/src/services/mempool_services.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use slog::info;
 
-use crypto::hash::{ChainId, HashType, OperationHash, ProtocolHash};
+use crypto::hash::{ChainId, OperationHash, ProtocolHash};
 use shell::mempool::CurrentMempoolStateStorageRef;
 use shell::shell_channel::{
     InjectBlock, MempoolOperationReceived, RequestCurrentHead, ShellChannelMsg, ShellChannelRef,
@@ -99,7 +99,7 @@ fn convert_applied(
 ) -> Result<Vec<HashMap<String, Value>>, failure::Error> {
     let mut result: Vec<HashMap<String, Value>> = Vec::new();
     for a in applied {
-        let operation_hash = HashType::OperationHash.hash_to_b58check(&a.hash);
+        let operation_hash = a.hash.to_base58_check();
         let protocol_data: HashMap<String, Value> = serde_json::from_str(&a.protocol_data_json)?;
         let operation = match operations.get(&a.hash) {
             Some(b) => b,
@@ -115,7 +115,7 @@ fn convert_applied(
         m.insert(String::from("hash"), Value::String(operation_hash));
         m.insert(
             String::from("branch"),
-            Value::String(HashType::BlockHash.hash_to_b58check(&operation.branch())),
+            Value::String(operation.branch().to_base58_check()),
         );
         m.extend(protocol_data);
         result.push(m);
@@ -130,10 +130,10 @@ fn convert_errored(
     protocol: &ProtocolHash,
 ) -> Result<Vec<Value>, failure::Error> {
     let mut result: Vec<Value> = Vec::new();
-    let protocol = HashType::ProtocolHash.hash_to_b58check(&protocol);
+    let protocol = protocol.to_base58_check();
 
     for e in errored {
-        let operation_hash = HashType::OperationHash.hash_to_b58check(&e.hash);
+        let operation_hash = e.hash.to_base58_check();
         let operation = match operations.get(&e.hash) {
             Some(b) => b,
             None => {
@@ -164,7 +164,7 @@ fn convert_errored(
         m.insert(String::from("protocol"), Value::String(protocol.clone()));
         m.insert(
             String::from("branch"),
-            Value::String(HashType::BlockHash.hash_to_b58check(&operation.branch())),
+            Value::String(operation.branch().to_base58_check()),
         );
         m.extend(protocol_data);
         m.insert(String::from("error"), error);
@@ -200,7 +200,7 @@ pub fn inject_operation(
 
     // parse operation data
     let operation: Operation = Operation::from_bytes(hex::decode(operation_data)?)?;
-    let operation_hash = operation.message_hash()?;
+    let operation_hash = operation.message_typed_hash()?;
 
     // do prevalidation before add the operation to mempool
     let result = validation::prevalidate_operation(
@@ -217,14 +217,14 @@ pub fn inject_operation(
     if !validation::can_accept_operation_from_rpc(&operation_hash, &result) {
         return Err(format_err!(
             "Operation from rpc ({}) was not added to mempool. Reason: {:?}",
-            HashType::OperationHash.hash_to_b58check(&operation_hash),
+            operation_hash.to_base58_check(),
             result
         ));
     }
 
     // store operation in mempool storage
     let mut mempool_storage = MempoolStorage::new(persistent_storage);
-    let operation_hash_b58check_string = HashType::OperationHash.hash_to_b58check(&operation_hash);
+    let operation_hash_b58check_string = operation_hash.to_base58_check();
     let ttl = SystemTime::now() + Duration::from_secs(60);
     mempool_storage.put(MempoolOperationType::Pending, operation.into(), ttl)?;
 
@@ -300,7 +300,7 @@ pub fn inject_block(
 
     let header: BlockHeaderWithHash =
         BlockHeader::from_bytes(hex::decode(block_with_op.data)?)?.try_into()?;
-    let block_hash_b58check_string = HashType::BlockHash.hash_to_b58check(&header.hash);
+    let block_hash_b58check_string = header.hash.to_base58_check();
     info!(env.log(),
           "Block injection requested";
           "block_hash" => block_hash_b58check_string.clone(),
@@ -329,7 +329,7 @@ pub fn inject_block(
 
         for vps in validation_passes {
             for vp in vps {
-                let oph: OperationHash = vp.message_hash()?;
+                let oph: OperationHash = vp.message_typed_hash()?;
                 current_mempool_state.remove_operation(oph);
             }
         }
@@ -422,12 +422,11 @@ pub fn request_operations(shell_channel: ShellChannelRef) -> Result<(), failure:
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::{collections::HashMap, convert::TryInto};
 
     use assert_json_diff::assert_json_eq;
     use serde_json::json;
 
-    use crypto::hash::HashType;
     use tezos_api::ffi::{Applied, Errored, OperationProtocolDataJsonWithErrorListJson};
     use tezos_messages::p2p::binary_message::BinaryMessage;
     use tezos_messages::p2p::encoding::prelude::Operation;
@@ -438,7 +437,7 @@ mod tests {
     fn test_convert_applied() -> Result<(), failure::Error> {
         let data = vec![
             Applied {
-                hash: HashType::OperationHash.b58check_to_hash("onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ")?,
+                hash: "onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ".try_into()?,
                 protocol_data_json: "{ \"contents\": [ { \"kind\": \"endorsement\", \"level\": 459020 } ],\n  \"signature\":\n    \"siguKbKFVDkXo2m1DqZyftSGg7GZRq43EVLSutfX5yRLXXfWYG5fegXsDT6EUUqawYpjYE1GkyCVHfc2kr3hcaDAvWSAhnV9\" }".to_string(),
             }
         ];
@@ -446,7 +445,7 @@ mod tests {
         let mut operations = HashMap::new();
         // operation with branch=BKqTKfGwK3zHnVXX33X5PPHy1FDTnbkajj3eFtCXGFyfimQhT1H
         operations.insert(
-            HashType::OperationHash.b58check_to_hash("onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ")?,
+            "onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ".try_into()?,
             Operation::from_bytes(hex::decode("10490b79070cf19175cd7e3b9c1ee66f6e85799980404b119132ea7e58a4a97e000008c387fa065a181d45d47a9b78ddc77e92a881779ff2cbabbf9646eade4bf1405a08e00b725ed849eea46953b10b5cdebc518e6fd47e69b82d2ca18c4cf6d2f312dd08")?)?,
         );
 
@@ -475,7 +474,7 @@ mod tests {
     fn test_convert_errored() -> Result<(), failure::Error> {
         let data = vec![
             Errored {
-                hash: HashType::OperationHash.b58check_to_hash("onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ")?,
+                hash: "onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ".try_into()?,
                 is_endorsement: None,
                 protocol_data_json_with_error_json: OperationProtocolDataJsonWithErrorListJson {
                     protocol_data_json: "{ \"contents\": [ { \"kind\": \"endorsement\", \"level\": 459020 } ],\n  \"signature\":\n    \"siguKbKFVDkXo2m1DqZyftSGg7GZRq43EVLSutfX5yRLXXfWYG5fegXsDT6EUUqawYpjYE1GkyCVHfc2kr3hcaDAvWSAhnV9\" }".to_string(),
@@ -487,11 +486,10 @@ mod tests {
         let mut operations = HashMap::new();
         // operation with branch=BKqTKfGwK3zHnVXX33X5PPHy1FDTnbkajj3eFtCXGFyfimQhT1H
         operations.insert(
-            HashType::OperationHash.b58check_to_hash("onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ")?,
+            "onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ".try_into()?,
             Operation::from_bytes(hex::decode("10490b79070cf19175cd7e3b9c1ee66f6e85799980404b119132ea7e58a4a97e000008c387fa065a181d45d47a9b78ddc77e92a881779ff2cbabbf9646eade4bf1405a08e00b725ed849eea46953b10b5cdebc518e6fd47e69b82d2ca18c4cf6d2f312dd08")?)?,
         );
-        let protocol = HashType::ProtocolHash
-            .b58check_to_hash("PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb")?;
+        let protocol = "PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb".try_into()?;
 
         let expected_json = json!(
                 [
@@ -522,7 +520,7 @@ mod tests {
     fn test_convert_errored_missing_protocol_data() -> Result<(), failure::Error> {
         let data = vec![
             Errored {
-                hash: HashType::OperationHash.b58check_to_hash("onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ")?,
+                hash: "onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ".try_into()?,
                 is_endorsement: Some(true),
                 protocol_data_json_with_error_json: OperationProtocolDataJsonWithErrorListJson {
                     protocol_data_json: "".to_string(),
@@ -534,11 +532,10 @@ mod tests {
         let mut operations = HashMap::new();
         // operation with branch=BKqTKfGwK3zHnVXX33X5PPHy1FDTnbkajj3eFtCXGFyfimQhT1H
         operations.insert(
-            HashType::OperationHash.b58check_to_hash("onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ")?,
+            "onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ".try_into()?,
             Operation::from_bytes(hex::decode("10490b79070cf19175cd7e3b9c1ee66f6e85799980404b119132ea7e58a4a97e000008c387fa065a181d45d47a9b78ddc77e92a881779ff2cbabbf9646eade4bf1405a08e00b725ed849eea46953b10b5cdebc518e6fd47e69b82d2ca18c4cf6d2f312dd08")?)?,
         );
-        let protocol = HashType::ProtocolHash
-            .b58check_to_hash("PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb")?;
+        let protocol = "PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb".try_into()?;
 
         let expected_json = json!(
                 [

--- a/rpc/src/services/protocol/mod.rs
+++ b/rpc/src/services/protocol/mod.rs
@@ -651,7 +651,7 @@ impl From<tezos_messages::protocol::ContextConstantsDecodeError> for ContextPara
 
 impl From<FromBytesError> for ContextParamsError {
     fn from(error: FromBytesError) -> ContextParamsError {
-        ContextParamsError::HashError{ error }
+        ContextParamsError::HashError { error }
     }
 }
 

--- a/rpc/src/services/stream_services.rs
+++ b/rpc/src/services/stream_services.rs
@@ -179,9 +179,7 @@ impl OperationMonitorStream {
                 .filter(|(k, _)| !streamed_operations.contains(k))
                 .map(|(_, v)| {
                     let mut monitor_op: MonitoredOperation = serde_json::from_value(v).unwrap();
-                    monitor_op.protocol = protocol_hash
-                        .as_ref()
-                        .map(|ph| ph.to_base58_check());
+                    monitor_op.protocol = protocol_hash.as_ref().map(|ph| ph.to_base58_check());
                     monitor_op
                 })
                 .collect();
@@ -212,9 +210,7 @@ impl OperationMonitorStream {
                             return Err(e);
                         }
                     };
-                    monitor_op.protocol = protocol_hash
-                        .as_ref()
-                        .map(|ph| ph.to_base58_check());
+                    monitor_op.protocol = protocol_hash.as_ref().map(|ph| ph.to_base58_check());
                     Ok(monitor_op)
                 })
                 .filter_map(Result::ok)

--- a/shell/src/chain_feeder.rs
+++ b/shell/src/chain_feeder.rs
@@ -429,7 +429,7 @@ fn feed_chain_to_protocol(
                                     warn!(log, "Failed to dispatch result to condvar"; "reason" => format!("{}", e));
                                 }
                                 return Err(FeedChainError::MissingContextError {
-                                    context_hash: apply_block_result.context_hash.to_base58_check()
+                                    context_hash: apply_block_result.context_hash.to_base58_check(),
                                 });
                             }
                             let context_wait_elapsed = context_wait_timer.elapsed();

--- a/shell/src/chain_manager.rs
+++ b/shell/src/chain_manager.rs
@@ -1115,9 +1115,10 @@ impl ChainManager {
             operations,
             operation_paths,
         } = injected_block;
-        let log = ctx.system.log().new(
-            slog::o!("block" => block_header_with_hash.hash.to_base58_check()),
-        );
+        let log = ctx
+            .system
+            .log()
+            .new(slog::o!("block" => block_header_with_hash.hash.to_base58_check()));
 
         // this should  allways return [is_new_block==true], as we are injecting a forged new block
         let (block_metadata, is_new_block, mut are_operations_complete) = match self
@@ -2354,11 +2355,11 @@ fn tell_peer(msg: Arc<PeerMessageResponse>, peer: &PeerState) {
 
 #[cfg(test)]
 pub mod tests {
-    use std::{convert::TryInto, net::SocketAddr};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc::channel;
     use std::sync::Mutex;
     use std::thread;
+    use std::{convert::TryInto, net::SocketAddr};
 
     use slog::{Drain, Level, Logger};
 

--- a/shell/src/chain_manager.rs
+++ b/shell/src/chain_manager.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use riker::actors::*;
 use slog::{debug, info, trace, warn, Logger};
 
-use crypto::hash::{BlockHash, ChainId, CryptoboxPublicKeyHash, HashType, OperationHash};
+use crypto::hash::{BlockHash, ChainId, CryptoboxPublicKeyHash, OperationHash};
 use crypto::seeded_step::Seed;
 use networking::p2p::network_channel::{NetworkChannelMsg, NetworkChannelRef, NetworkChannelTopic};
 use networking::p2p::peer::SendMessage;
@@ -552,7 +552,7 @@ impl ChainManager {
                                     {
                                         let head = message.current_branch().current_head();
                                         debug!(log, "Ignoring received (low) current branch";
-                                                    "branch" => HashType::BlockHash.hash_to_b58check(&head.message_hash()?),
+                                                    "branch" => head.message_typed_hash::<BlockHash>()?.to_base58_check(),
                                                     "level" => head.level());
                                     } else {
                                         let message_current_head = BlockHeaderWithHash::new(
@@ -618,7 +618,7 @@ impl ChainManager {
                                             }
                                         }
                                     } else {
-                                        warn!(log, "Peer is requesting current branch from unsupported chain_id"; "chain_id" => HashType::ChainId.hash_to_b58check(chain_state.get_chain_id()));
+                                        warn!(log, "Peer is requesting current branch from unsupported chain_id"; "chain_id" => chain_state.get_chain_id().to_base58_check());
                                     }
                                 }
                                 PeerMessage::BlockHeader(message) => {
@@ -643,7 +643,7 @@ impl ChainManager {
                                             )?;
                                         }
                                         None => {
-                                            warn!(log, "Received unexpected block header"; "block_header_hash" => HashType::BlockHash.hash_to_b58check(&block_header_with_hash.hash));
+                                            warn!(log, "Received unexpected block header"; "block_header_hash" => block_header_with_hash.hash.to_base58_check());
                                         }
                                     }
                                 }
@@ -691,7 +691,7 @@ impl ChainManager {
                                             if operation_was_expected {
                                                 peer.block_operations_response_last =
                                                     Instant::now();
-                                                trace!(log, "Received operations validation pass"; "validation_pass" => operations.operations_for_block().validation_pass(), "block_header_hash" => HashType::BlockHash.hash_to_b58check(&block_hash));
+                                                trace!(log, "Received operations validation pass"; "validation_pass" => operations.operations_for_block().validation_pass(), "block_header_hash" => block_hash.to_base58_check());
 
                                                 if operations_state
                                                     .process_block_operations(&operations)?
@@ -748,7 +748,7 @@ impl ChainManager {
                                                         .remove(&block_hash);
                                                 }
                                             } else {
-                                                warn!(log, "Received unexpected validation pass"; "validation_pass" => operations.operations_for_block().validation_pass(), "block_header_hash" => HashType::BlockHash.hash_to_b58check(&block_hash));
+                                                warn!(log, "Received unexpected validation pass"; "validation_pass" => operations.operations_for_block().validation_pass(), "block_header_hash" => block_hash.to_base58_check());
                                                 ctx.system.stop(received.peer.clone());
                                             }
                                         }
@@ -883,7 +883,7 @@ impl ChainManager {
                                     // handling new mempool operations here
                                     // parse operation data
                                     let operation = message.operation();
-                                    let operation_hash = operation.message_hash()?;
+                                    let operation_hash = operation.message_typed_hash()?;
 
                                     match peer.queued_mempool_operations.remove(&operation_hash) {
                                         Some((operation_type, op_ttl)) => {
@@ -906,7 +906,7 @@ impl ChainManager {
                                                     }
                                                     poe => {
                                                         // other error just propagate
-                                                        return Err(format_err!("Operation from p2p ({}) was not added to mempool. Reason: {:?}", HashType::OperationHash.hash_to_b58check(&operation_hash), poe));
+                                                        return Err(format_err!("Operation from p2p ({}) was not added to mempool. Reason: {:?}", operation_hash.to_base58_check(), poe));
                                                     }
                                                 }
                                             };
@@ -916,7 +916,7 @@ impl ChainManager {
                                                 &operation_hash,
                                                 &result,
                                             ) {
-                                                return Err(format_err!("Operation from p2p ({}) was not added to mempool. Reason: {:?}", HashType::OperationHash.hash_to_b58check(&operation_hash), result));
+                                                return Err(format_err!("Operation from p2p ({}) was not added to mempool. Reason: {:?}", operation_hash.to_base58_check(), result));
                                             }
 
                                             // store mempool operation
@@ -1014,7 +1014,7 @@ impl ChainManager {
                 } else {
                     return Err(format_err!(
                         "BlockHeader ({}) was not found!",
-                        HashType::BlockHash.hash_to_b58check(&block_hash)
+                        block_hash.to_base58_check()
                     ));
                 }
             }
@@ -1026,7 +1026,7 @@ impl ChainManager {
                     peers, chain_state, ..
                 } = self;
                 let msg: Arc<PeerMessageResponse> =
-                    GetCurrentHeadMessage::new(chain_state.get_chain_id().to_vec()).into();
+                    GetCurrentHeadMessage::new(chain_state.get_chain_id().clone()).into();
                 peers
                     .iter_mut()
                     .for_each(|(_, peer)| tell_peer(msg.clone(), peer));
@@ -1116,7 +1116,7 @@ impl ChainManager {
             operation_paths,
         } = injected_block;
         let log = ctx.system.log().new(
-            slog::o!("block" => HashType::BlockHash.hash_to_b58check(&block_header_with_hash.hash)),
+            slog::o!("block" => block_header_with_hash.hash.to_base58_check()),
         );
 
         // this should  allways return [is_new_block==true], as we are injecting a forged new block
@@ -1137,7 +1137,7 @@ impl ChainManager {
                     || {
                         Err(format_err!(
                             "Failed to store injected block, block_hash: {}, reason: {}",
-                            HashType::BlockHash.hash_to_b58check(&block_header_with_hash.hash),
+                            block_header_with_hash.hash.to_base58_check(),
                             e
                         ))
                     },
@@ -1178,8 +1178,7 @@ impl ChainManager {
                             || {
                                 Err(format_err!(
                                     "Missing operations in request, block_hash: {}",
-                                    HashType::BlockHash
-                                        .hash_to_b58check(&block_header_with_hash.hash)
+                                    block_header_with_hash.hash.to_base58_check()
                                 ))
                             },
                             true,
@@ -1188,7 +1187,7 @@ impl ChainManager {
                         }
                         return Err(format_err!(
                             "Missing operations in request, block_hash: {}",
-                            HashType::BlockHash.hash_to_b58check(&block_header_with_hash.hash)
+                            block_header_with_hash.hash.to_base58_check()
                         ));
                     }
                 };
@@ -1200,8 +1199,7 @@ impl ChainManager {
                             || {
                                 Err(format_err!(
                                     "Missing operation paths in request, block_hash: {}",
-                                    HashType::BlockHash
-                                        .hash_to_b58check(&block_header_with_hash.hash)
+                                    block_header_with_hash.hash.to_base58_check()
                                 ))
                             },
                             true,
@@ -1210,7 +1208,7 @@ impl ChainManager {
                         }
                         return Err(format_err!(
                             "Missing operation paths in request, block_hash: {}",
-                            HashType::BlockHash.hash_to_b58check(&block_header_with_hash.hash)
+                            block_header_with_hash.hash.to_base58_check()
                         ));
                     }
                 };
@@ -1228,7 +1226,7 @@ impl ChainManager {
                             if let Err(e) = dispatch_condvar_result(
                                 result_callback,
                                 || {
-                                    Err(format_err!("Missing operation paths in request for index: {}, block_hash: {}", idx, HashType::BlockHash.hash_to_b58check(&block_header_with_hash.hash)))
+                                    Err(format_err!("Missing operation paths in request for index: {}, block_hash: {}", idx, block_header_with_hash.hash.to_base58_check()))
                                 },
                                 true,
                             ) {
@@ -1237,7 +1235,7 @@ impl ChainManager {
                             return Err(format_err!(
                                 "Missing operation paths in request for index: {}, block_hash: {}",
                                 idx,
-                                HashType::BlockHash.hash_to_b58check(&block_header_with_hash.hash)
+                                block_header_with_hash.hash.to_base58_check()
                             ));
                         }
                     };
@@ -1273,7 +1271,7 @@ impl ChainManager {
                             if let Err(e) = dispatch_condvar_result(
                                 result_callback,
                                 || {
-                                    Err(format_err!("Failed to store injected block operations, block_hash: {}, reason: {}", HashType::BlockHash.hash_to_b58check(&block_header_with_hash.hash), e))
+                                    Err(format_err!("Failed to store injected block operations, block_hash: {}, reason: {}", block_header_with_hash.hash.to_base58_check(), e))
                                 },
                                 true,
                             ) {
@@ -1302,12 +1300,12 @@ impl ChainManager {
                         );
                     } else {
                         warn!(log, "Injected block cannot be applied - will be ignored!";
-                                   "block_predecessor" => HashType::BlockHash.hash_to_b58check(&block_header_with_hash.header.predecessor()),
+                                   "block_predecessor" => block_header_with_hash.header.predecessor().to_base58_check(),
                                    "are_operations_complete" => are_operations_complete);
                         if let Err(e) = dispatch_condvar_result(
                             result_callback,
                             || {
-                                Err(format_err!("Injected block cannot be applied - will be ignored!, block_hash: {}, are_operations_complete: {}", HashType::BlockHash.hash_to_b58check(&block_header_with_hash.hash), are_operations_complete))
+                                Err(format_err!("Injected block cannot be applied - will be ignored!, block_hash: {}, are_operations_complete: {}", block_header_with_hash.hash.to_base58_check(), are_operations_complete))
                             },
                             true,
                         ) {
@@ -1319,7 +1317,7 @@ impl ChainManager {
                     if let Err(e) = dispatch_condvar_result(
                         result_callback,
                         || {
-                            Err(format_err!("Failed to detect if injected block can be applied, block_hash: {}, reason: {}", HashType::BlockHash.hash_to_b58check(&block_header_with_hash.hash), e))
+                            Err(format_err!("Failed to detect if injected block can be applied, block_hash: {}, reason: {}", block_header_with_hash.hash.to_base58_check(), e))
                         },
                         true,
                     ) {
@@ -1335,7 +1333,7 @@ impl ChainManager {
                 || {
                     Err(format_err!(
                         "Injected duplicated block - will be ignored!, block_hash: {}",
-                        HashType::BlockHash.hash_to_b58check(&block_header_with_hash.hash)
+                        block_header_with_hash.hash.to_base58_check()
                     ))
                 },
                 true,
@@ -1379,7 +1377,7 @@ impl ChainManager {
             None => {
                 return Err(format_err!(
                     "Block/json_data not found for block_hash: {}",
-                    HashType::BlockHash.hash_to_b58check(&block)
+                    block.to_base58_check()
                 ));
             }
         };
@@ -1391,7 +1389,7 @@ impl ChainManager {
             self.current_mempool_state.clone(),
         )? {
             debug!(ctx.system.log(), "New current head";
-                                     "block_header_hash" => HashType::BlockHash.hash_to_b58check(new_head.block_hash()),
+                                     "block_header_hash" => new_head.block_hash().to_base58_check(),
                                      "level" => new_head.level(),
                                      "is_bootstrapped" => self.is_bootstrapped,
                                      "result" => format!("{}", new_head_result)
@@ -1572,14 +1570,14 @@ impl ChainManager {
             Some(meta) => {
                 if meta.is_applied() {
                     // block already applied - ok, doing nothing
-                    debug!(ctx.system.log(), "Block is already applied"; "block" => HashType::BlockHash.hash_to_b58check(&msg.block_hash));
+                    debug!(ctx.system.log(), "Block is already applied"; "block" => msg.block_hash.to_base58_check());
                     return Ok(());
                 }
             }
             None => {
                 return Err(format_err!(
                     "Block metadata not found for block_hash: {}",
-                    HashType::BlockHash.hash_to_b58check(&msg.block_hash)
+                    msg.block_hash.to_base58_check()
                 ));
             }
         }
@@ -2356,7 +2354,7 @@ fn tell_peer(msg: Arc<PeerMessageResponse>, peer: &PeerState) {
 
 #[cfg(test)]
 pub mod tests {
-    use std::net::SocketAddr;
+    use std::{convert::TryInto, net::SocketAddr};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::mpsc::channel;
     use std::sync::Mutex;
@@ -2412,8 +2410,7 @@ pub mod tests {
         let node_identity = Arc::new(Identity::generate(0f64));
         let peer_public_key_hash: CryptoboxPublicKeyHash =
             node_identity.public_key.public_key_hash();
-        let peer_id_marker =
-            HashType::CryptoboxPublicKeyHash.hash_to_b58check(&peer_public_key_hash);
+        let peer_id_marker = peer_public_key_hash.to_base58_check();
 
         let peer_ref = Peer::actor(
             sys,
@@ -2465,7 +2462,7 @@ pub mod tests {
             ShellChannel::actor(&actor_system).expect("Failed to create shell channel");
         let network_channel =
             NetworkChannel::actor(&actor_system).expect("Failed to create network channel");
-        let chain_id = HashType::ChainId.b58check_to_hash("NetXgtSLGNJvNye")?;
+        let chain_id = ChainId::from_base58_check("NetXgtSLGNJvNye")?;
         let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
             .get(&TezosEnvironment::Sandbox)
             .expect("no environment configuration");
@@ -2550,8 +2547,7 @@ pub mod tests {
 
         // simulate - block applied event with level 4
         let new_head = Head::new(
-            HashType::BlockHash
-                .b58check_to_hash("BLFQ2JjYWHC95Db21cRZC4cgyA1mcXmx1Eg6jKywWy9b8xLzyK9")?,
+            "BLFQ2JjYWHC95Db21cRZC4cgyA1mcXmx1Eg6jKywWy9b8xLzyK9".try_into()?,
             4,
             vec![],
         );
@@ -2563,8 +2559,7 @@ pub mod tests {
 
         // simulate - block applied event with level 5
         let new_head = Head::new(
-            HashType::BlockHash
-                .b58check_to_hash("BLFQ2JjYWHC95Db21cRZC4cgyA1mcXmx1Eg6jKywWy9b8xLzyK9")?,
+            "BLFQ2JjYWHC95Db21cRZC4cgyA1mcXmx1Eg6jKywWy9b8xLzyK9".try_into()?,
             5,
             vec![],
         );

--- a/shell/src/context_listener.rs
+++ b/shell/src/context_listener.rs
@@ -3,12 +3,12 @@
 
 //! Listens for events from the `protocol_runner`.
 
+use std::convert::TryFrom;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
-use std::convert::TryFrom;
 
 use failure::Error;
 use riker::actors::*;
@@ -274,7 +274,6 @@ fn listen_protocol_events(
                         ..
                     } => {
                         if !ignored {
-
                             let context_hash = try_from_untyped_option(context_hash)?;
                             context.remove_recursively_to_diff(&context_hash, key)?;
                         }
@@ -328,11 +327,11 @@ fn listen_protocol_events(
     Ok(())
 }
 
-
 fn try_from_untyped_option<H>(h: &Option<Vec<u8>>) -> Result<Option<H>, FromBytesError>
-where H: TryFrom<Vec<u8>, Error = FromBytesError>
+where
+    H: TryFrom<Vec<u8>, Error = FromBytesError>,
 {
     h.as_ref()
-     .map(|h| H::try_from(h.clone()))
-     .map_or(Ok(None), |r| r.map(Some))
+        .map(|h| H::try_from(h.clone()))
+        .map_or(Ok(None), |r| r.map(Some))
 }

--- a/shell/src/context_listener.rs
+++ b/shell/src/context_listener.rs
@@ -8,12 +8,13 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
+use std::convert::TryFrom;
 
 use failure::Error;
 use riker::actors::*;
 use slog::{crit, debug, info, warn, Logger};
 
-use crypto::hash::HashType;
+use crypto::hash::{BlockHash, ContextHash, FromBytesError, HashType};
 use storage::context::{ContextApi, TezedgeContext};
 use storage::persistent::PersistentStorage;
 use storage::{BlockStorage, ContextActionStorage};
@@ -177,7 +178,7 @@ fn store_action(
             block_hash: Some(block_hash),
             ..
         } => {
-            storage.put_action(&block_hash.clone(), action)?;
+            storage.put_action(&BlockHash::try_from(block_hash.clone())?, action)?;
             Ok(())
         }
         _ => Ok(()),
@@ -215,7 +216,7 @@ fn listen_protocol_events(
                         "count" => event_count,
                         "context_hash" => match &context.get_last_commit_hash() {
                             None => "-none-".to_string(),
-                            Some(c) => HashType::ContextHash.hash_to_b58check(c)
+                            Some(c) => HashType::ContextHash.hash_to_b58check(c)?
                         }
                     );
                 }
@@ -239,7 +240,8 @@ fn listen_protocol_events(
                         ..
                     } => {
                         if !ignored {
-                            context.set(context_hash, key, value)?;
+                            let context_hash = try_from_untyped_option(context_hash)?;
+                            context.set(&context_hash, key, value)?;
                         }
                     }
                     ContextAction::Copy {
@@ -250,7 +252,8 @@ fn listen_protocol_events(
                         ..
                     } => {
                         if !ignored {
-                            context.copy_to_diff(context_hash, from_key, key)?;
+                            let context_hash = try_from_untyped_option(context_hash)?;
+                            context.copy_to_diff(&context_hash, from_key, key)?;
                         }
                     }
                     ContextAction::Delete {
@@ -260,7 +263,8 @@ fn listen_protocol_events(
                         ..
                     } => {
                         if !ignored {
-                            context.delete_to_diff(context_hash, key)?;
+                            let context_hash = try_from_untyped_option(context_hash)?;
+                            context.delete_to_diff(&context_hash, key)?;
                         }
                     }
                     ContextAction::RemoveRecursively {
@@ -270,7 +274,9 @@ fn listen_protocol_events(
                         ..
                     } => {
                         if !ignored {
-                            context.remove_recursively_to_diff(context_hash, key)?;
+
+                            let context_hash = try_from_untyped_option(context_hash)?;
+                            context.remove_recursively_to_diff(&context_hash, key)?;
                         }
                     }
                     ContextAction::Commit {
@@ -282,26 +288,30 @@ fn listen_protocol_events(
                         date,
                         ..
                     } => {
+                        let parent_context_hash = try_from_untyped_option(parent_context_hash)?;
+                        let block_hash = BlockHash::try_from(block_hash.clone())?;
+                        let new_context_hash = ContextHash::try_from(new_context_hash.clone())?;
+
                         let hash = context.commit(
-                            block_hash,
-                            parent_context_hash,
+                            &block_hash,
+                            &parent_context_hash,
                             author.to_string(),
                             message.to_string(),
                             *date,
                         )?;
                         assert_eq!(
-                            &hash,
+                            hash,
                             new_context_hash,
                             "Invalid context_hash for block: {}, expected: {}, but was: {}",
-                            HashType::BlockHash.hash_to_b58check(block_hash),
-                            HashType::ContextHash.hash_to_b58check(new_context_hash),
-                            HashType::ContextHash.hash_to_b58check(&hash),
+                            block_hash.to_base58_check(),
+                            new_context_hash.to_base58_check(),
+                            hash.to_base58_check(),
                         );
                     }
 
                     ContextAction::Checkout { context_hash, .. } => {
                         event_count = 0;
-                        context.checkout(context_hash)?;
+                        context.checkout(&ContextHash::try_from(context_hash.clone())?)?;
                     }
                     _ => (),
                 };
@@ -316,4 +326,13 @@ fn listen_protocol_events(
     }
 
     Ok(())
+}
+
+
+fn try_from_untyped_option<H>(h: &Option<Vec<u8>>) -> Result<Option<H>, FromBytesError>
+where H: TryFrom<Vec<u8>, Error = FromBytesError>
+{
+    h.as_ref()
+     .map(|h| H::try_from(h.clone()))
+     .map_or(Ok(None), |r| r.map(Some))
 }

--- a/shell/src/mempool/mempool_state.rs
+++ b/shell/src/mempool/mempool_state.rs
@@ -234,7 +234,8 @@ impl From<&MempoolState> for Mempool {
 
 #[cfg(test)]
 mod tests {
-    use crypto::hash::HashType;
+    use std::convert::TryInto;
+
     use tezos_api::ffi::PrevalidatorWrapper;
     use tezos_messages::p2p::binary_message::BinaryMessage;
     use tezos_messages::p2p::encoding::prelude::Operation;
@@ -243,10 +244,8 @@ mod tests {
 
     #[test]
     fn test_state_reinit() -> Result<(), failure::Error> {
-        let op_hash1 = HashType::OperationHash
-            .b58check_to_hash("opJ4FdKumPfykAP9ZqwY7rNB8y1SiMupt44RqBDMWL7cmb4xbNr")?;
-        let op_hash2 = HashType::OperationHash
-            .b58check_to_hash("onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ")?;
+        let op_hash1 = "opJ4FdKumPfykAP9ZqwY7rNB8y1SiMupt44RqBDMWL7cmb4xbNr".try_into()?;
+        let op_hash2 = "onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ".try_into()?;
 
         // init state with two pendings
         let mut state = MempoolState::default();
@@ -267,15 +266,11 @@ mod tests {
         // add header/prevalidator
         let _ = state.reinit(
             Some(PrevalidatorWrapper {
-                chain_id: HashType::ChainId.b58check_to_hash("NetXgtSLGNJvNye")?,
-                protocol: HashType::ProtocolHash
-                    .b58check_to_hash("PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb")?,
+                chain_id: "NetXgtSLGNJvNye".try_into()?,
+                protocol: "PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb".try_into()?,
                 context_fitness: Some(vec![vec![0, 1], vec![0, 0, 1, 2, 3, 4, 5]]),
             }),
-            Some(
-                HashType::BlockHash
-                    .b58check_to_hash("BLFQ2JjYWHC95Db21cRZC4cgyA1mcXmx1Eg6jKywWy9b8xLzyK9")?,
-            ),
+            Some("BLFQ2JjYWHC95Db21cRZC4cgyA1mcXmx1Eg6jKywWy9b8xLzyK9".try_into()?),
         );
 
         // remove from pending

--- a/shell/src/state/block_state.rs
+++ b/shell/src/state/block_state.rs
@@ -1,10 +1,10 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::{cmp, convert::TryFrom};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
+use std::{cmp, convert::TryFrom};
 
 use rand::prelude::ThreadRng;
 use rand::Rng;
@@ -194,9 +194,7 @@ impl BlockchainState {
                                 if let Some(Some(protocol_hash)) = protocol_hash {
                                     // return next_protocol and header
                                     (
-                                        Some(
-                                            ProtocolHash::from_base58_check(protocol_hash)?,
-                                        ),
+                                        Some(ProtocolHash::from_base58_check(protocol_hash)?),
                                         Some(predecessor_header),
                                         false,
                                     )
@@ -699,7 +697,10 @@ mod tests {
     use super::*;
 
     fn block(d: u8) -> BlockHash {
-        [d; crypto::hash::HashType::BlockHash.size()].to_vec().try_into().unwrap()
+        [d; crypto::hash::HashType::BlockHash.size()]
+            .to_vec()
+            .try_into()
+            .unwrap()
     }
 
     #[test]
@@ -1020,8 +1021,8 @@ mod tests {
             };
 
             ($blocks:ident, $name:expr, $block_hash:expr, $block_hash_expected:expr, $block_header_hex_data:expr) => {
-                let block_hash = BlockHash::from_base58_check($block_hash)
-                    .expect("Failed to create block hash");
+                let block_hash =
+                    BlockHash::from_base58_check($block_hash).expect("Failed to create block hash");
                 let block_hash_expected = BlockHash::from_base58_check($block_hash_expected)
                     .expect("Failed to create block hash");
                 $blocks.insert(
@@ -1269,7 +1270,8 @@ mod tests {
                 .map(|c| c as u8)
                 .take(HashType::CryptoboxPublicKeyHash.size())
                 .collect::<Vec<_>>()
-                .try_into().unwrap()
+                .try_into()
+                .unwrap()
         }
 
         pub(crate) fn assert_history(

--- a/shell/src/state/block_state.rs
+++ b/shell/src/state/block_state.rs
@@ -1,7 +1,7 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::cmp;
+use std::{cmp, convert::TryFrom};
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt;
@@ -10,7 +10,7 @@ use rand::prelude::ThreadRng;
 use rand::Rng;
 use slog::Logger;
 
-use crypto::hash::{BlockHash, ChainId, HashType, ProtocolHash};
+use crypto::hash::{BlockHash, ChainId, ProtocolHash};
 use crypto::seeded_step::{Seed, Step};
 use storage::block_meta_storage::Meta;
 use storage::chain_meta_storage::ChainMetaStorageReader;
@@ -195,8 +195,7 @@ impl BlockchainState {
                                     // return next_protocol and header
                                     (
                                         Some(
-                                            HashType::ProtocolHash
-                                                .b58check_to_hash(protocol_hash)?,
+                                            ProtocolHash::from_base58_check(protocol_hash)?,
                                         ),
                                         Some(predecessor_header),
                                         false,
@@ -205,7 +204,7 @@ impl BlockchainState {
                                     return Err(
                                         failure::format_err!(
                                             "Missing `next_protocol` attribute for applied predecessor: {}!",
-                                            HashType::BlockHash.hash_to_b58check(validated_header.predecessor())
+                                            validated_header.predecessor().to_base58_check()
                                         )
                                     );
                                 }
@@ -213,8 +212,7 @@ impl BlockchainState {
                             None => {
                                 return Err(failure::format_err!(
                                     "Missing data for applied predecessor: {}!",
-                                    HashType::BlockHash
-                                        .hash_to_b58check(validated_header.predecessor())
+                                    validated_header.predecessor().to_base58_check()
                                 ));
                             }
                         }
@@ -251,15 +249,14 @@ impl BlockchainState {
                         if let Some(Some(protocol_hash)) = protocol_hash {
                             // return protocol
                             Ok((
-                                Some(HashType::ProtocolHash.b58check_to_hash(protocol_hash)?),
+                                Some(ProtocolHash::try_from(protocol_hash)?),
                                 predecessor_header,
                                 missing_predecessor,
                             ))
                         } else {
                             return Err(failure::format_err!(
                                 "Missing `next_protocol` attribute for applied predecessor: {}!",
-                                HashType::BlockHash
-                                    .hash_to_b58check(validated_header.predecessor())
+                                validated_header.predecessor().to_base58_check()
                             ));
                         }
                     } else {
@@ -269,7 +266,7 @@ impl BlockchainState {
                 None => {
                     return Err(failure::format_err!(
                         "Missing data for applied current_head: {}!",
-                        HashType::BlockHash.hash_to_b58check(current_head.block_hash())
+                        current_head.block_hash().to_base58_check()
                     ));
                 }
             }
@@ -692,6 +689,8 @@ impl fmt::Display for HeadResult {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryInto;
+
     use slog::{Drain, Level, Logger};
 
     use crypto::hash::chain_id_from_block_hash;
@@ -699,20 +698,24 @@ mod tests {
 
     use super::*;
 
+    fn block(d: u8) -> BlockHash {
+        [d; crypto::hash::HashType::BlockHash.size()].to_vec().try_into().unwrap()
+    }
+
     #[test]
     fn test_missing_blocks_has_correct_ordering() {
         let mut heap = UniqueBlockData::new();
 
         // simulate header and predecesor
-        heap.push(MissingBlock::with_level(vec![0, 0, 0, 1], 10));
-        heap.push(MissingBlock::with_level(vec![0, 0, 0, 2], 9));
+        heap.push(MissingBlock::with_level(block(1), 10));
+        heap.push(MissingBlock::with_level(block(2), 9));
 
         // simulate history
-        heap.push(MissingBlock::with_level_guess(vec![0, 0, 0, 3], 4));
-        heap.push(MissingBlock::with_level_guess(vec![0, 0, 0, 7], 0));
-        heap.push(MissingBlock::with_level_guess(vec![0, 0, 0, 5], 2));
-        heap.push(MissingBlock::with_level_guess(vec![0, 0, 0, 6], 1));
-        heap.push(MissingBlock::with_level_guess(vec![0, 0, 0, 4], 3));
+        heap.push(MissingBlock::with_level_guess(block(3), 4));
+        heap.push(MissingBlock::with_level_guess(block(7), 0));
+        heap.push(MissingBlock::with_level_guess(block(5), 2));
+        heap.push(MissingBlock::with_level_guess(block(6), 1));
+        heap.push(MissingBlock::with_level_guess(block(4), 3));
 
         // pop all from heap
         let ordered_hashes = (0..heap.len())
@@ -721,14 +724,14 @@ mod tests {
             .collect::<Vec<BlockHash>>();
 
         // from level: 0, 1, 2, 3, 4, 9, 10
-        let expected_order = vec![
-            vec![0, 0, 0, 7],
-            vec![0, 0, 0, 6],
-            vec![0, 0, 0, 5],
-            vec![0, 0, 0, 4],
-            vec![0, 0, 0, 3],
-            vec![0, 0, 0, 2],
-            vec![0, 0, 0, 1],
+        let expected_order: Vec<BlockHash> = vec![
+            block(7),
+            block(6),
+            block(5),
+            block(4),
+            block(3),
+            block(2),
+            block(1),
         ];
 
         assert_eq!(expected_order, ordered_hashes)
@@ -995,12 +998,12 @@ mod tests {
     }
 
     mod data {
-        use std::collections::HashMap;
+        use std::{collections::HashMap, convert::TryInto};
 
         use itertools::Itertools;
         use slog::Logger;
 
-        use crypto::hash::{BlockHash, CryptoboxPublicKeyHash, HashType};
+        use crypto::hash::{BlockHash, ChainId, CryptoboxPublicKeyHash, HashType};
         use storage::{BlockHeaderWithHash, BlockMetaStorage, BlockStorage, BlockStorageReader};
         use tezos_messages::p2p::binary_message::BinaryMessage;
         use tezos_messages::p2p::encoding::block_header::BlockHeader;
@@ -1017,11 +1020,9 @@ mod tests {
             };
 
             ($blocks:ident, $name:expr, $block_hash:expr, $block_hash_expected:expr, $block_header_hex_data:expr) => {
-                let block_hash = HashType::BlockHash
-                    .b58check_to_hash($block_hash)
+                let block_hash = BlockHash::from_base58_check($block_hash)
                     .expect("Failed to create block hash");
-                let block_hash_expected = HashType::BlockHash
-                    .b58check_to_hash($block_hash_expected)
+                let block_hash_expected = BlockHash::from_base58_check($block_hash_expected)
                     .expect("Failed to create block hash");
                 $blocks.insert(
                     $name,
@@ -1039,7 +1040,7 @@ mod tests {
                 );
                 let (hash, header) = $blocks.get($name).unwrap();
                 assert_eq!(block_hash, *hash);
-                assert_eq!(block_hash_expected, *header.hash);
+                assert_eq!(block_hash_expected, header.hash);
             };
         }
 
@@ -1209,7 +1210,7 @@ mod tests {
 
         pub(crate) fn store_branch(
             branch: &Vec<&str>,
-            chain_id: &Vec<u8>,
+            chain_id: &ChainId,
             blocks: &BlocksDb,
             block_storage: &BlockStorage,
             block_meta_storage: &BlockMetaStorage,
@@ -1265,9 +1266,10 @@ mod tests {
 
         pub(crate) fn generate_key_string(c: char) -> CryptoboxPublicKeyHash {
             std::iter::repeat(c)
+                .map(|c| c as u8)
                 .take(HashType::CryptoboxPublicKeyHash.size())
-                .collect::<String>()
-                .into_bytes()
+                .collect::<Vec<_>>()
+                .try_into().unwrap()
         }
 
         pub(crate) fn assert_history(

--- a/shell/src/state/operations_state.rs
+++ b/shell/src/state/operations_state.rs
@@ -211,27 +211,31 @@ impl From<&MissingOperations> for Vec<OperationsForBlock> {
 mod tests {
     use super::*;
 
+    fn block(d: u8) -> BlockHash {
+        [d; crypto::hash::HashType::BlockHash.size()].to_vec().try_into().unwrap()
+    }
+
     #[test]
     fn missing_operation_has_correct_ordering() {
         let mut heap = UniqueBlockData::new();
         heap.push(MissingOperations {
             level: 15,
-            block_hash: vec![0, 0, 0, 1],
+            block_hash: block(1),
             validation_passes: HashSet::new(),
         });
         heap.push(MissingOperations {
             level: 7,
-            block_hash: vec![0, 0, 0, 9],
+            block_hash: block(9),
             validation_passes: HashSet::new(),
         });
         heap.push(MissingOperations {
             level: 0,
-            block_hash: vec![0, 0, 0, 4],
+            block_hash: block(4),
             validation_passes: HashSet::new(),
         });
         heap.push(MissingOperations {
             level: 1,
-            block_hash: vec![0, 0, 0, 5],
+            block_hash: block(5),
             validation_passes: HashSet::new(),
         });
 

--- a/shell/src/state/operations_state.rs
+++ b/shell/src/state/operations_state.rs
@@ -212,7 +212,10 @@ mod tests {
     use super::*;
 
     fn block(d: u8) -> BlockHash {
-        [d; crypto::hash::HashType::BlockHash.size()].to_vec().try_into().unwrap()
+        [d; crypto::hash::HashType::BlockHash.size()]
+            .to_vec()
+            .try_into()
+            .unwrap()
     }
 
     #[test]

--- a/shell/tests/actors_apply_blocks_test.rs
+++ b/shell/tests/actors_apply_blocks_test.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant, SystemTime};
 use riker::actors::*;
 use slog::{info, Logger};
 
-use crypto::hash::{BlockHash, ChainId, ContextHash, HashType, OperationHash};
+use crypto::hash::{BlockHash, ChainId, ContextHash, OperationHash};
 use shell::shell_channel::{MempoolOperationReceived, ShellChannelRef, ShellChannelTopic};
 use storage::chain_meta_storage::ChainMetaStorageReader;
 use storage::context::{ContextApi, TezedgeContext};
@@ -142,7 +142,7 @@ fn check_context(
     {
         assert_eq!(
             "PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS",
-            HashType::ProtocolHash.hash_to_b58check(&data)
+            crypto::hash::HashType::ProtocolHash.hash_to_b58check(&data)?
         );
     } else {
         panic!(format!("Protocol not found in context for level: {}", 2));
@@ -155,7 +155,7 @@ fn check_context(
     let merkle_last_hash = merkle.get_last_commit_hash();
 
     // compare with context hash of last applied expected_context_hash
-    assert_eq!(*expected_context_hash, merkle_last_hash.unwrap());
+    assert_eq!(expected_context_hash.as_ref(), &merkle_last_hash.unwrap().to_vec());
 
     // print stats
     let stats = merkle.get_merkle_stats().unwrap();
@@ -237,7 +237,7 @@ fn init_storage_data(
     operations: &HashMap<OperationsForBlocksMessageKey, OperationsForBlocksMessage>,
     apply_to_level: i32,
     persistent_storage: &PersistentStorage,
-    chain_id: &Vec<u8>,
+    chain_id: &ChainId,
 ) -> Result<(), failure::Error> {
     println!("\n[Insert] Initialize storage data started...");
 
@@ -256,7 +256,7 @@ fn init_storage_data(
 
         // store header to db
         let block = BlockHeaderWithHash {
-            hash: header.message_hash()?,
+            hash: header.message_typed_hash()?,
             header: Arc::new(header),
         };
         block_storage.put_block_header(&block)?;
@@ -301,7 +301,7 @@ fn test_scenario_for_add_operations_to_mempool_and_check_state(
     // wait mempool for last_applied_block
     let last_applied_block: BlockHash = samples::from_captured_bytes(last_applied_request_1324)?
         .block_header
-        .message_hash()?;
+        .message_typed_hash()?;
     node.wait_for_mempool_on_head(
         "mempool_head_1324",
         last_applied_block.clone(),
@@ -410,7 +410,7 @@ fn add_operations_to_mempool(
         for operation in operations {
             // this is done by chain_manager when received new operations
 
-            let operation_hash = operation.message_hash()?;
+            let operation_hash: OperationHash = operation.message_typed_hash()?;
 
             // add to mempool storage
             mempool_storage.put(

--- a/shell/tests/actors_apply_blocks_test.rs
+++ b/shell/tests/actors_apply_blocks_test.rs
@@ -155,7 +155,10 @@ fn check_context(
     let merkle_last_hash = merkle.get_last_commit_hash();
 
     // compare with context hash of last applied expected_context_hash
-    assert_eq!(expected_context_hash.as_ref(), &merkle_last_hash.unwrap().to_vec());
+    assert_eq!(
+        expected_context_hash.as_ref(),
+        &merkle_last_hash.unwrap().to_vec()
+    );
 
     // print stats
     let stats = merkle.get_merkle_stats().unwrap();

--- a/shell/tests/chain_test.rs
+++ b/shell/tests/chain_test.rs
@@ -634,7 +634,10 @@ fn process_bootstrap_level1324_and_mempool_for_level1325(
         .get_operations(&db.block_hash(1325)?)?
         .iter()
         .flatten()
-        .map(|a| a.message_typed_hash().expect("Failed to decode operation has"))
+        .map(|a| {
+            a.message_typed_hash()
+                .expect("Failed to decode operation has")
+        })
         .collect();
     mocked_peer_node.clear_mempool();
     mocked_peer_node.send_msg(CurrentHeadMessage::new(
@@ -762,7 +765,8 @@ mod test_data {
                 for ops in request.operations {
                     for op in ops {
                         operation_hashes.insert(
-                            op.message_typed_hash().expect("Failed to compute message hash"),
+                            op.message_typed_hash()
+                                .expect("Failed to compute message hash"),
                             level,
                         );
                     }

--- a/shell/tests/chain_test.rs
+++ b/shell/tests/chain_test.rs
@@ -634,7 +634,7 @@ fn process_bootstrap_level1324_and_mempool_for_level1325(
         .get_operations(&db.block_hash(1325)?)?
         .iter()
         .flatten()
-        .map(|a| a.message_hash().expect("Failed to decode operation has"))
+        .map(|a| a.message_typed_hash().expect("Failed to decode operation has"))
         .collect();
     mocked_peer_node.clear_mempool();
     mocked_peer_node.send_msg(CurrentHeadMessage::new(
@@ -754,7 +754,7 @@ mod test_data {
 
                 let block = request
                     .block_header
-                    .message_hash()
+                    .message_typed_hash()
                     .expect("Failed to decode message_hash");
                 let context_hash: ContextHash = request.block_header.context().clone();
                 headers.insert(block, (level, context_hash));
@@ -762,7 +762,7 @@ mod test_data {
                 for ops in request.operations {
                     for op in ops {
                         operation_hashes.insert(
-                            op.message_hash().expect("Failed to compute message hash"),
+                            op.message_typed_hash().expect("Failed to compute message hash"),
                             level,
                         );
                     }
@@ -794,7 +794,7 @@ mod test_data {
                     let mut found = None;
                     for ops in self.captured_requests(*level)?.operations {
                         for op in ops {
-                            if op.message_hash()?.eq(operation_hash) {
+                            if op.message_typed_hash::<OperationHash>()?.eq(operation_hash) {
                                 found = Some(op);
                                 break;
                             }
@@ -1533,7 +1533,7 @@ mod test_actor {
 
     use riker::actors::*;
 
-    use crypto::hash::{CryptoboxPublicKeyHash, HashType};
+    use crypto::hash::CryptoboxPublicKeyHash;
     use networking::p2p::network_channel::{NetworkChannelMsg, NetworkChannelRef};
     use shell::subscription::subscribe_to_network_events;
 
@@ -1681,7 +1681,7 @@ mod test_actor {
                     break Err(
                         failure::format_err!(
                             "[{}] verify_state - peer_public_key({}) - (expected_state: {}) - timeout (timeout: {:?}, delay: {:?}) exceeded!",
-                            peer.name, HashType::CryptoboxPublicKeyHash.hash_to_b58check(peer_public_key_hash), expected_state, timeout, delay
+                            peer.name, peer_public_key_hash.to_base58_check(), expected_state, timeout, delay
                         )
                     );
                 }

--- a/shell/tests/common/mod.rs
+++ b/shell/tests/common/mod.rs
@@ -450,9 +450,7 @@ pub mod infra {
                     .current_mempool_state_storage
                     .read()
                     .expect("Failed to obtain lock");
-                let current_head = mempool_state
-                    .head()
-                    .map(|ch| ch.to_base58_check());
+                let current_head = mempool_state.head().map(|ch| ch.to_base58_check());
 
                 if current_head.eq(&tested_head) {
                     info!(self.log, "[NODE] Expected mempool head detected"; "head" => tested_head, "marker" => marker);

--- a/shell/tests/samples.rs
+++ b/shell/tests/samples.rs
@@ -1,10 +1,10 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::{collections::HashMap, convert::TryFrom};
 use std::fs::File;
 use std::io::BufRead;
 use std::path::Path;
+use std::{collections::HashMap, convert::TryFrom};
 use std::{env, io};
 
 use itertools::Itertools;
@@ -129,8 +129,7 @@ pub fn read_data_zip(
             let split = line.split('|').collect_vec();
             assert_eq!(3, split.len());
 
-            let block_hash = BlockHash::try_from(split[0])
-                .expect("Failed to parse block_hash");
+            let block_hash = BlockHash::try_from(split[0]).expect("Failed to parse block_hash");
             let validation_pass = split[1]
                 .parse::<i8>()
                 .expect("Failed to parse validation_pass");

--- a/shell/tests/samples.rs
+++ b/shell/tests/samples.rs
@@ -1,7 +1,7 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::TryFrom};
 use std::fs::File;
 use std::io::BufRead;
 use std::path::Path;
@@ -58,7 +58,7 @@ pub struct OperationsForBlocksMessageKey {
 impl OperationsForBlocksMessageKey {
     pub fn new(block_hash: BlockHash, validation_pass: i8) -> Self {
         OperationsForBlocksMessageKey {
-            block_hash: HashType::BlockHash.hash_to_b58check(&block_hash),
+            block_hash: block_hash.to_base58_check(),
             validation_pass,
         }
     }
@@ -129,8 +129,7 @@ pub fn read_data_zip(
             let split = line.split('|').collect_vec();
             assert_eq!(3, split.len());
 
-            let block_hash = HashType::BlockHash
-                .b58check_to_hash(split[0])
+            let block_hash = BlockHash::try_from(split[0])
                 .expect("Failed to parse block_hash");
             let validation_pass = split[1]
                 .parse::<i8>()

--- a/storage/benches/predecessor_benchmarks.rs
+++ b/storage/benches/predecessor_benchmarks.rs
@@ -70,8 +70,8 @@ fn init_mocked_storage(number_of_blocks: usize) -> Result<(BlockMetaStorage, Blo
     let mut block_hash_set = HashSet::new();
     let mut rng = rand::thread_rng();
 
-    let k = vec![0; 32];
-    let v = Meta::new(false, Some(vec![0; 32]), 0, vec![44; 4]);
+    let k: BlockHash = vec![0; 32].try_into()?;
+    let v = Meta::new(false, Some(vec![0; 32].try_into()?), 0, vec![44; 4].try_into()?);
 
     block_hash_set.insert(k.clone());
 
@@ -84,10 +84,10 @@ fn init_mocked_storage(number_of_blocks: usize) -> Result<(BlockMetaStorage, Blo
     // generate random block hashes, watch out for colissions
     let block_hashes: Vec<BlockHash> = (1..number_of_blocks)
         .map(|_| {
-            let mut random_hash: BlockHash = (0..32).map(|_| rng.gen_range(0, 255)).collect();
+            let mut random_hash: BlockHash = (0..32).map(|_| rng.gen_range(0, 255)).collect::<Vec<_>>().try_into().unwrap();
             // regenerate on collision
             while block_hash_set.contains(&random_hash) {
-                random_hash = (0..32).map(|_| rng.gen_range(0, 255)).collect();
+                random_hash = (0..32).map(|_| rng.gen_range(0, 255)).collect::<Vec<_>>().try_into().unwrap();
             }
             block_hash_set.insert(random_hash.clone());
             random_hash
@@ -100,7 +100,7 @@ fn init_mocked_storage(number_of_blocks: usize) -> Result<(BlockMetaStorage, Blo
             true,
             Some(predecessor.clone()),
             idx.try_into()?,
-            vec![44; 4],
+            vec![44; 4].try_into()?,
         );
         storage.put(&block_hash, &v)?;
         storage.store_predecessors(&block_hash, &v)?;

--- a/storage/benches/predecessor_benchmarks.rs
+++ b/storage/benches/predecessor_benchmarks.rs
@@ -71,7 +71,12 @@ fn init_mocked_storage(number_of_blocks: usize) -> Result<(BlockMetaStorage, Blo
     let mut rng = rand::thread_rng();
 
     let k: BlockHash = vec![0; 32].try_into()?;
-    let v = Meta::new(false, Some(vec![0; 32].try_into()?), 0, vec![44; 4].try_into()?);
+    let v = Meta::new(
+        false,
+        Some(vec![0; 32].try_into()?),
+        0,
+        vec![44; 4].try_into()?,
+    );
 
     block_hash_set.insert(k.clone());
 
@@ -84,10 +89,18 @@ fn init_mocked_storage(number_of_blocks: usize) -> Result<(BlockMetaStorage, Blo
     // generate random block hashes, watch out for colissions
     let block_hashes: Vec<BlockHash> = (1..number_of_blocks)
         .map(|_| {
-            let mut random_hash: BlockHash = (0..32).map(|_| rng.gen_range(0, 255)).collect::<Vec<_>>().try_into().unwrap();
+            let mut random_hash: BlockHash = (0..32)
+                .map(|_| rng.gen_range(0, 255))
+                .collect::<Vec<_>>()
+                .try_into()
+                .unwrap();
             // regenerate on collision
             while block_hash_set.contains(&random_hash) {
-                random_hash = (0..32).map(|_| rng.gen_range(0, 255)).collect::<Vec<_>>().try_into().unwrap();
+                random_hash = (0..32)
+                    .map(|_| rng.gen_range(0, 255))
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap();
             }
             block_hash_set.insert(random_hash.clone());
             random_hash

--- a/storage/src/block_meta_storage.rs
+++ b/storage/src/block_meta_storage.rs
@@ -660,7 +660,10 @@ mod tests {
         storage.put(&k, &v)?;
 
         // add successor
-        v.successors = vec![vec![21; 32].try_into().unwrap(), vec![121; 32].try_into().unwrap()];
+        v.successors = vec![
+            vec![21; 32].try_into().unwrap(),
+            vec![121; 32].try_into().unwrap(),
+        ];
         storage.put(&k, &v)?;
 
         // check stored meta
@@ -669,7 +672,10 @@ mod tests {
                 let expected = Meta {
                     is_applied: true,
                     predecessor: Some(vec![98; 32].try_into().unwrap()),
-                    successors: vec![vec![21; 32].try_into().unwrap(), vec![121; 32].try_into().unwrap()],
+                    successors: vec![
+                        vec![21; 32].try_into().unwrap(),
+                        vec![121; 32].try_into().unwrap(),
+                    ],
                     level: 1_245_762,
                     chain_id: vec![44; 4].try_into().unwrap(),
                 };
@@ -721,7 +727,7 @@ mod tests {
                 &DbConfiguration::default(),
             )
             .unwrap();
-            let k : BlockHash = vec![44; 32].try_into().unwrap();
+            let k: BlockHash = vec![44; 32].try_into().unwrap();
             let mut v = Meta {
                 is_applied: false,
                 predecessor: None,
@@ -773,7 +779,12 @@ mod tests {
         let mut rng = rand::thread_rng();
 
         let k: BlockHash = vec![0; 32].try_into().unwrap();
-        let v = Meta::new(false, Some(vec![0; 32].try_into().unwrap()), 0, vec![44; 4].try_into().unwrap());
+        let v = Meta::new(
+            false,
+            Some(vec![0; 32].try_into().unwrap()),
+            0,
+            vec![44; 4].try_into().unwrap(),
+        );
 
         block_hash_set.insert(k.clone());
 
@@ -789,10 +800,18 @@ mod tests {
         // we can  deduct its level from its index in the vector)
         let block_hashes: Vec<BlockHash> = (1..number_of_blocks)
             .map(|_| {
-                let mut random_hash = (0..32).map(|_| rng.gen_range(0, 255)).collect::<Vec<_>>().try_into().unwrap();
+                let mut random_hash = (0..32)
+                    .map(|_| rng.gen_range(0, 255))
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .unwrap();
                 // regenerate on collision
                 while block_hash_set.contains(&random_hash) {
-                    random_hash = (0..32).map(|_| rng.gen_range(0, 255)).collect::<Vec<_>>().try_into().unwrap();
+                    random_hash = (0..32)
+                        .map(|_| rng.gen_range(0, 255))
+                        .collect::<Vec<_>>()
+                        .try_into()
+                        .unwrap();
                 }
                 block_hash_set.insert(random_hash.clone());
                 random_hash

--- a/storage/src/block_meta_storage.rs
+++ b/storage/src/block_meta_storage.rs
@@ -1,7 +1,9 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::sync::Arc;
+use std::{convert::TryInto, sync::Arc};
+
+use std::convert::TryFrom;
 
 use getset::{CopyGetters, Getters, Setters};
 use rocksdb::{Cache, ColumnFamilyDescriptor, MergeOperands};
@@ -75,9 +77,9 @@ impl BlockMetaStorage {
                         if *stored_predecessor != block_predecessor {
                             warn!(
                                 log, "Detected rewriting predecessor - not allowed (change is just ignored)";
-                                "block_hash" => HashType::BlockHash.hash_to_b58check(&block_header.hash),
-                                "stored_predecessor" => HashType::BlockHash.hash_to_b58check(&stored_predecessor),
-                                "new_predecessor" => HashType::BlockHash.hash_to_b58check(&block_predecessor)
+                                "block_hash" => block_header.hash.to_base58_check(),
+                                "stored_predecessor" => stored_predecessor.to_base58_check(),
+                                "new_predecessor" => block_predecessor.to_base58_check()
                             );
                         }
                     }
@@ -118,15 +120,15 @@ impl BlockMetaStorage {
                         if !meta.successors.contains(&block_hash) {
                             warn!(
                                 log, "Extending successors - means detected reorg or new branch";
-                                "block_hash_predecessor" => HashType::BlockHash.hash_to_b58check(&block_header.header.predecessor()),
+                                "block_hash_predecessor" => block_header.header.predecessor().to_base58_check(),
                                 "stored_successors" => {
                                     meta.successors
                                         .iter()
-                                        .map(|bh| HashType::BlockHash.hash_to_b58check(bh))
+                                        .map(|bh| bh.to_base58_check())
                                         .collect::<Vec<String>>()
                                         .join(", ")
                                 },
-                                "new_successor" => HashType::BlockHash.hash_to_b58check(&block_hash)
+                                "new_successor" => block_hash.to_base58_check()
                             );
                             true
                         } else {
@@ -406,7 +408,7 @@ impl Decoder for Meta {
                     LEN_BLOCK_HASH,
                     block_hash.len()
                 );
-                Some(block_hash)
+                Some(block_hash.try_into()?)
             } else {
                 None
             };
@@ -432,7 +434,7 @@ impl Decoder for Meta {
                             LEN_BLOCK_HASH,
                             block_hash.len()
                         );
-                        successors.push(block_hash);
+                        successors.push(BlockHash::try_from(block_hash)?);
                     }
                 }
                 successors
@@ -450,7 +452,7 @@ impl Decoder for Meta {
                 successors,
                 is_applied: is_processed,
                 level,
-                chain_id,
+                chain_id: chain_id.try_into()?,
             })
         } else {
             Err(SchemaError::DecodeError)
@@ -476,15 +478,15 @@ impl Encoder for Meta {
         let mut value = Vec::with_capacity(total_len);
         value.push(mask);
         match &self.predecessor {
-            Some(predecessor) => value.extend(predecessor),
+            Some(predecessor) => value.extend(predecessor.as_ref()),
             None => value.extend(&BLANK_BLOCK_HASH),
         }
         value.extend(&self.level.to_be_bytes());
-        value.extend(&self.chain_id);
+        value.extend(self.chain_id.as_ref());
         value.extend(&successors_count.to_be_bytes());
         if successors_count > 0 {
             self.successors.iter().for_each(|successor| {
-                value.extend(successor);
+                value.extend(successor.as_ref());
             });
         }
         assert_eq!(
@@ -581,8 +583,6 @@ mod tests {
     use failure::Error;
     use rand::Rng;
 
-    use crypto::hash::HashType;
-
     use crate::persistent::{open_kv, DbConfiguration};
     use crate::tests_common::TmpStorage;
 
@@ -592,10 +592,10 @@ mod tests {
     fn block_meta_encoded_equals_decoded() -> Result<(), Error> {
         let expected = Meta {
             is_applied: false,
-            predecessor: Some(vec![98; 32]),
-            successors: vec![vec![21; 32]],
+            predecessor: Some(vec![98; 32].try_into().unwrap()),
+            successors: vec![vec![21; 32].try_into().unwrap()],
             level: 34,
-            chain_id: vec![44; 4],
+            chain_id: vec![44; 4].try_into().unwrap(),
         };
         let encoded_bytes = expected.encode()?;
         let decoded = Meta::decode(&encoded_bytes)?;
@@ -607,9 +607,8 @@ mod tests {
     fn genesis_block_initialized_success() -> Result<(), Error> {
         let tmp_storage = TmpStorage::create("__blockmeta_genesistest")?;
 
-        let k = HashType::BlockHash
-            .b58check_to_hash("BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe")?;
-        let chain_id = HashType::ChainId.b58check_to_hash("NetXgtSLGNJvNye")?;
+        let k = "BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe".try_into()?;
+        let chain_id = "NetXgtSLGNJvNye".try_into()?;
         let v = Meta::genesis_meta(&k, &chain_id, true);
         let storage = BlockMetaStorage::new(tmp_storage.storage());
         storage.put(&k, &v)?;
@@ -634,13 +633,13 @@ mod tests {
     fn block_meta_storage_test() -> Result<(), Error> {
         let tmp_storage = TmpStorage::create("__blockmeta_storagetest")?;
 
-        let k = vec![44; 32];
+        let k = vec![44; 32].try_into().unwrap();
         let mut v = Meta {
             is_applied: false,
             predecessor: None,
             successors: vec![],
             level: 1_245_762,
-            chain_id: vec![44; 4],
+            chain_id: vec![44; 4].try_into().unwrap(),
         };
         let storage = BlockMetaStorage::new(tmp_storage.storage());
         storage.put(&k, &v)?;
@@ -648,8 +647,8 @@ mod tests {
 
         // change applied to true and predecessor + add successor
         v.is_applied = true;
-        v.predecessor = Some(vec![98; 32]);
-        v.successors = vec![vec![21; 32]];
+        v.predecessor = Some(vec![98; 32].try_into().unwrap());
+        v.successors = vec![vec![21; 32].try_into().unwrap()];
         storage.put(&k, &v)?;
 
         // try change is_applied (cannot be overwritten - see merge_meta_value)
@@ -657,11 +656,11 @@ mod tests {
         storage.put(&k, &v)?;
 
         // try change predecessor (cannot be overwritten - see merge_meta_value)
-        v.predecessor = Some(vec![198; 32]);
+        v.predecessor = Some(vec![198; 32].try_into().unwrap());
         storage.put(&k, &v)?;
 
         // add successor
-        v.successors = vec![vec![21; 32], vec![121; 32]];
+        v.successors = vec![vec![21; 32].try_into().unwrap(), vec![121; 32].try_into().unwrap()];
         storage.put(&k, &v)?;
 
         // check stored meta
@@ -669,10 +668,10 @@ mod tests {
             Some(value) => {
                 let expected = Meta {
                     is_applied: true,
-                    predecessor: Some(vec![98; 32]),
-                    successors: vec![vec![21; 32], vec![121; 32]],
+                    predecessor: Some(vec![98; 32].try_into().unwrap()),
+                    successors: vec![vec![21; 32].try_into().unwrap(), vec![121; 32].try_into().unwrap()],
                     level: 1_245_762,
-                    chain_id: vec![44; 4],
+                    chain_id: vec![44; 4].try_into().unwrap(),
                 };
                 assert_eq!(expected, value);
             }
@@ -684,7 +683,7 @@ mod tests {
         storage.put(&k, &v)?;
 
         // modify successors
-        v.successors = vec![vec![121; 32]];
+        v.successors = vec![vec![121; 32].try_into().unwrap()];
         storage.put(&k, &v)?;
 
         // check stored meta
@@ -692,10 +691,10 @@ mod tests {
             Some(value) => {
                 let expected = Meta {
                     is_applied: true,
-                    predecessor: Some(vec![98; 32]),
-                    successors: vec![vec![121; 32]],
+                    predecessor: Some(vec![98; 32].try_into().unwrap()),
+                    successors: vec![vec![121; 32].try_into().unwrap()],
                     level: 1_245_762,
-                    chain_id: vec![44; 4],
+                    chain_id: vec![44; 4].try_into().unwrap(),
                 };
                 assert_eq!(expected, value);
             }
@@ -722,22 +721,22 @@ mod tests {
                 &DbConfiguration::default(),
             )
             .unwrap();
-            let k = vec![44; 32];
+            let k : BlockHash = vec![44; 32].try_into().unwrap();
             let mut v = Meta {
                 is_applied: false,
                 predecessor: None,
                 successors: vec![],
                 level: 2,
-                chain_id: vec![44; 4],
+                chain_id: vec![44; 4].try_into().unwrap(),
             };
             let p = BlockMetaStorageKV::merge(&db, &k, &v);
             assert!(p.is_ok(), "p: {:?}", p.unwrap_err());
             v.is_applied = true;
-            v.successors = vec![vec![21; 32]];
+            v.successors = vec![vec![21; 32].try_into().unwrap()];
             let _ = BlockMetaStorageKV::merge(&db, &k, &v);
 
             v.is_applied = false;
-            v.predecessor = Some(vec![98; 32]);
+            v.predecessor = Some(vec![98; 32].try_into().unwrap());
             v.successors = vec![];
             let _ = BlockMetaStorageKV::merge(&db, &k, &v);
 
@@ -749,10 +748,10 @@ mod tests {
                 Ok(Some(value)) => {
                     let expected = Meta {
                         is_applied: true,
-                        predecessor: Some(vec![98; 32]),
+                        predecessor: Some(vec![98; 32].try_into().unwrap()),
                         successors: vec![],
                         level: 2,
-                        chain_id: vec![44; 4],
+                        chain_id: vec![44; 4].try_into().unwrap(),
                     };
                     assert_eq!(expected, value);
                 }
@@ -773,8 +772,8 @@ mod tests {
         let mut block_hash_set = HashSet::new();
         let mut rng = rand::thread_rng();
 
-        let k = vec![0; 32];
-        let v = Meta::new(false, Some(vec![0; 32]), 0, vec![44; 4]);
+        let k: BlockHash = vec![0; 32].try_into().unwrap();
+        let v = Meta::new(false, Some(vec![0; 32].try_into().unwrap()), 0, vec![44; 4].try_into().unwrap());
 
         block_hash_set.insert(k.clone());
 
@@ -790,10 +789,10 @@ mod tests {
         // we can  deduct its level from its index in the vector)
         let block_hashes: Vec<BlockHash> = (1..number_of_blocks)
             .map(|_| {
-                let mut random_hash: BlockHash = (0..32).map(|_| rng.gen_range(0, 255)).collect();
+                let mut random_hash = (0..32).map(|_| rng.gen_range(0, 255)).collect::<Vec<_>>().try_into().unwrap();
                 // regenerate on collision
                 while block_hash_set.contains(&random_hash) {
-                    random_hash = (0..32).map(|_| rng.gen_range(0, 255)).collect();
+                    random_hash = (0..32).map(|_| rng.gen_range(0, 255)).collect::<Vec<_>>().try_into().unwrap();
                 }
                 block_hash_set.insert(random_hash.clone());
                 random_hash
@@ -806,7 +805,7 @@ mod tests {
                 true,
                 Some(predecessor.clone()),
                 idx.try_into()?,
-                vec![44; 4],
+                vec![44; 4].try_into().unwrap(),
             );
             storage.put(&block_hash, &v)?;
             storage.store_predecessors(&block_hash, &v)?;
@@ -872,7 +871,7 @@ mod tests {
                 println!("Checked {} blocks from {}", idx, BLOCK_COUNT);
             }
             for i in 1..idx {
-                let res = storage.find_block_at_distance(hash.to_vec(), i as i32)?;
+                let res = storage.find_block_at_distance(hash.clone(), i as i32)?;
                 assert_eq!(block_hashes[idx - i], res.unwrap())
             }
         }

--- a/storage/src/context.rs
+++ b/storage/src/context.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: MIT
 
 use std::array::TryFromSliceError;
+use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::num::TryFromIntError;
 use std::sync::{Arc, RwLock};
-use std::convert::TryFrom;
 
 use failure::Fail;
 

--- a/storage/src/context.rs
+++ b/storage/src/context.rs
@@ -5,10 +5,11 @@ use std::array::TryFromSliceError;
 use std::convert::TryInto;
 use std::num::TryFromIntError;
 use std::sync::{Arc, RwLock};
+use std::convert::TryFrom;
 
 use failure::Fail;
 
-use crypto::hash::{BlockHash, ContextHash, HashType};
+use crypto::hash::{BlockHash, ContextHash, FromBytesError};
 
 use crate::merkle_storage::{
     ContextKey, ContextValue, EntryHash, MerkleError, MerkleStorage, MerkleStorageStats,
@@ -104,7 +105,7 @@ impl ContextApi for TezedgeContext {
     }
 
     fn checkout(&self, context_hash: &ContextHash) -> Result<(), ContextError> {
-        let context_hash_arr: EntryHash = context_hash.as_slice().try_into()?;
+        let context_hash_arr: EntryHash = context_hash.as_ref().as_slice().try_into()?;
         let mut merkle = self.merkle.write().expect("lock poisoning");
         merkle.checkout(&context_hash_arr)?;
 
@@ -123,7 +124,7 @@ impl ContextApi for TezedgeContext {
 
         let date: u64 = date.try_into()?;
         let commit_hash = merkle.commit(date, author, message)?;
-        let commit_hash = &commit_hash[..].to_vec();
+        let commit_hash = ContextHash::try_from(&commit_hash[..])?;
 
         // associate block and context_hash
         if let Err(e) = self
@@ -135,8 +136,8 @@ impl ContextApi for TezedgeContext {
                     // TODO: is this needed? check it when removing assign_to_context
                     if parent_context_hash.is_some() {
                         return Err(ContextError::ContextHashAssignError {
-                            block_hash: HashType::BlockHash.hash_to_b58check(block_hash),
-                            context_hash: HashType::ContextHash.hash_to_b58check(commit_hash),
+                            block_hash: block_hash.to_base58_check(),
+                            context_hash: commit_hash.to_base58_check(),
                             error: e,
                         });
                     } else {
@@ -147,15 +148,15 @@ impl ContextApi for TezedgeContext {
                 }
                 _ => {
                     return Err(ContextError::ContextHashAssignError {
-                        block_hash: HashType::BlockHash.hash_to_b58check(block_hash),
-                        context_hash: HashType::ContextHash.hash_to_b58check(commit_hash),
+                        block_hash: block_hash.to_base58_check(),
+                        context_hash: commit_hash.to_base58_check(),
                         error: e,
                     })
                 }
             };
         }
 
-        Ok(commit_hash.to_vec())
+        Ok(commit_hash)
     }
 
     fn delete_to_diff(
@@ -212,13 +213,13 @@ impl ContextApi for TezedgeContext {
         context_hash: &ContextHash,
         key: &ContextKey,
     ) -> Result<Option<ContextValue>, ContextError> {
-        let context_hash_arr: EntryHash = context_hash.as_slice().try_into()?;
+        let context_hash_arr: EntryHash = context_hash.as_ref().as_slice().try_into()?;
         let mut merkle = self.merkle.write().expect("lock poisoning");
         match merkle.get_history(&context_hash_arr, key) {
             Err(MerkleError::ValueNotFound { key: _ }) => Ok(None),
             Err(MerkleError::EntryNotFound { hash: _ }) => {
                 Err(ContextError::UnknownContextHashError {
-                    context_hash: HashType::ContextHash.hash_to_b58check(context_hash),
+                    context_hash: context_hash.to_base58_check(),
                 })
             }
             Err(err) => Err(ContextError::MerkleStorageError { error: err }),
@@ -231,7 +232,7 @@ impl ContextApi for TezedgeContext {
         context_hash: &ContextHash,
         prefix: &ContextKey,
     ) -> Result<Option<Vec<(ContextKey, ContextValue)>>, MerkleError> {
-        let context_hash_arr: EntryHash = context_hash.as_slice().try_into()?;
+        let context_hash_arr: EntryHash = context_hash.as_ref().as_slice().try_into()?;
         let mut merkle = self.merkle.write().expect("lock poisoning");
         merkle.get_key_values_by_prefix(&context_hash_arr, prefix)
     }
@@ -242,7 +243,7 @@ impl ContextApi for TezedgeContext {
         prefix: &ContextKey,
         depth: Option<usize>,
     ) -> Result<StringTreeEntry, MerkleError> {
-        let context_hash_arr: EntryHash = context_hash.as_slice().try_into()?;
+        let context_hash_arr: EntryHash = context_hash.as_ref().as_slice().try_into()?;
         let mut merkle = self.merkle.write().expect("lock poisoning");
         merkle.get_context_tree_by_prefix(&context_hash_arr, prefix, depth)
     }
@@ -309,6 +310,8 @@ pub enum ContextError {
     /// TODO: TE-203 - remove when context_listener will not be used
     #[fail(display = "Storage error: {}", error)]
     StorageError { error: StorageError },
+    #[fail(display = "Conversion from bytes error: {}", error)]
+    HashError { error: FromBytesError },
 }
 
 impl From<MerkleError> for ContextError {
@@ -326,6 +329,12 @@ impl From<TryFromIntError> for ContextError {
 impl From<TryFromSliceError> for ContextError {
     fn from(error: TryFromSliceError) -> Self {
         ContextError::HashConversionError { error }
+    }
+}
+
+impl From<FromBytesError> for ContextError {
+    fn from(error: FromBytesError) -> Self {
+        ContextError::HashError { error }
     }
 }
 

--- a/storage/src/context_action_storage.rs
+++ b/storage/src/context_action_storage.rs
@@ -2,22 +2,24 @@
 // SPDX-License-Identifier: MIT
 
 use std::cmp::Ordering;
+use std::convert::TryFrom;
 use std::mem;
 use std::ops::Range;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::convert::TryFrom;
 
 use failure::Fail;
 use rocksdb::{Cache, ColumnFamilyDescriptor, SliceTransform};
 use serde::{Deserialize, Serialize};
 
-use crypto::hash::{BlockHash, ContractKt1Hash, ContractTz1Hash, ContractTz2Hash, ContractTz3Hash, HashType};
+use crypto::hash::{
+    BlockHash, ContractKt1Hash, ContractTz1Hash, ContractTz2Hash, ContractTz3Hash, HashType,
+};
 use tezos_context::channel::ContextAction;
 use tezos_messages::base::signature_public_key_hash::{ConversionError, SignaturePublicKeyHash};
 
 use crate::num_from_slice;
-use crate::persistent::codec::{range_from_idx_len};
+use crate::persistent::codec::range_from_idx_len;
 use crate::persistent::sequence::{SequenceGenerator, SequenceNumber};
 use crate::persistent::{
     default_table_options, BincodeEncoded, Decoder, Encoder, KeyValueSchema,
@@ -419,7 +421,9 @@ impl ContextActionByBlockHashKey {
 impl Decoder for ContextActionByBlockHashKey {
     fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
         if Self::LEN_TOTAL == bytes.len() {
-            let block_hash = BlockHash::try_from(&bytes[Self::IDX_BLOCK_HASH..Self::IDX_BLOCK_HASH+Self::LEN_BLOCK_HASH])?;
+            let block_hash = BlockHash::try_from(
+                &bytes[Self::IDX_BLOCK_HASH..Self::IDX_BLOCK_HASH + Self::LEN_BLOCK_HASH],
+            )?;
             let id = num_from_slice!(bytes, Self::IDX_ID, SequenceNumber);
             Ok(Self { block_hash, id })
         } else {
@@ -636,23 +640,19 @@ pub fn contract_id_to_contract_address_for_index(
             match &contract_id[0..3] {
                 "tz1" => {
                     contract_address.extend(&[0, 0]);
-                    contract_address
-                        .extend(ContractTz1Hash::try_from(contract_id)?.as_ref());
+                    contract_address.extend(ContractTz1Hash::try_from(contract_id)?.as_ref());
                 }
                 "tz2" => {
                     contract_address.extend(&[0, 1]);
-                    contract_address
-                        .extend(ContractTz2Hash::try_from(contract_id)?.as_ref());
+                    contract_address.extend(ContractTz2Hash::try_from(contract_id)?.as_ref());
                 }
                 "tz3" => {
                     contract_address.extend(&[0, 2]);
-                    contract_address
-                        .extend(ContractTz3Hash::try_from(contract_id)?.as_ref());
+                    contract_address.extend(ContractTz3Hash::try_from(contract_id)?.as_ref());
                 }
                 "KT1" => {
                     contract_address.push(1);
-                    contract_address
-                        .extend(ContractKt1Hash::try_from(contract_id)?.as_ref());
+                    contract_address.extend(ContractKt1Hash::try_from(contract_id)?.as_ref());
                     contract_address.push(0);
                 }
                 _ => {

--- a/storage/src/mempool_storage.rs
+++ b/storage/src/mempool_storage.rs
@@ -1,11 +1,11 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use std::convert::TryFrom;
 use std::fmt;
 use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::SystemTime;
-use std::convert::TryFrom;
 
 use serde::{Deserialize, Serialize};
 
@@ -216,7 +216,8 @@ impl Decoder for MempoolKey {
             let operation_type =
                 MempoolOperationType::from_u8(num_from_slice!(bytes, Self::IDX_TYPE, u8))
                     .map_err(|_| SchemaError::DecodeError)?;
-            let operation_hash = OperationHash::try_from(&bytes[Self::IDX_HASH..Self::IDX_HASH + Self::LEN_HASH])?;
+            let operation_hash =
+                OperationHash::try_from(&bytes[Self::IDX_HASH..Self::IDX_HASH + Self::LEN_HASH])?;
             Ok(MempoolKey {
                 operation_type,
                 operation_hash,

--- a/storage/src/mempool_storage.rs
+++ b/storage/src/mempool_storage.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::fmt::Formatter;
 use std::sync::Arc;
 use std::time::SystemTime;
+use std::convert::TryFrom;
 
 use serde::{Deserialize, Serialize};
 
@@ -95,7 +96,7 @@ impl MempoolStorage {
     ) -> Result<(), StorageError> {
         let key = MempoolKey {
             operation_type,
-            operation_hash: operation.message_hash()?,
+            operation_hash: OperationHash::try_from(operation.message_hash()?)?,
         };
         let value = MempoolValue {
             operation,
@@ -198,10 +199,10 @@ impl MempoolKey {
 
 impl Encoder for MempoolKey {
     fn encode(&self) -> Result<Vec<u8>, SchemaError> {
-        if self.operation_hash.len() == Self::LEN_HASH {
+        if self.operation_hash.as_ref().len() == Self::LEN_HASH {
             let mut bytes = Vec::with_capacity(Self::LEN_KEY);
             bytes.push(self.operation_type.to_u8());
-            bytes.extend(&self.operation_hash);
+            bytes.extend(self.operation_hash.as_ref());
             Ok(bytes)
         } else {
             Err(SchemaError::EncodeError)
@@ -215,7 +216,7 @@ impl Decoder for MempoolKey {
             let operation_type =
                 MempoolOperationType::from_u8(num_from_slice!(bytes, Self::IDX_TYPE, u8))
                     .map_err(|_| SchemaError::DecodeError)?;
-            let operation_hash = bytes[Self::IDX_HASH..Self::IDX_HASH + Self::LEN_HASH].to_vec();
+            let operation_hash = OperationHash::try_from(&bytes[Self::IDX_HASH..Self::IDX_HASH + Self::LEN_HASH])?;
             Ok(MempoolKey {
                 operation_type,
                 operation_hash,

--- a/storage/src/operations_meta_storage.rs
+++ b/storage/src/operations_meta_storage.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 use std::collections::HashSet;
-use std::sync::Arc;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
 use rocksdb::{Cache, ColumnFamilyDescriptor, MergeOperands};
 
@@ -234,7 +234,8 @@ impl Decoder for Meta {
             );
             // chain_id
             let chain_id_pos = level_pos + std::mem::size_of::<i32>();
-            let chain_id = ChainId::try_from(&bytes[chain_id_pos..chain_id_pos + HashType::ChainId.size()])?;
+            let chain_id =
+                ChainId::try_from(&bytes[chain_id_pos..chain_id_pos + HashType::ChainId.size()])?;
             Ok(Meta {
                 validation_passes,
                 is_validation_pass_present,
@@ -285,7 +286,6 @@ mod tests {
     use std::{convert::TryInto, path::Path};
 
     use failure::Error;
-
 
     use crate::persistent::{open_kv, DbConfiguration};
     use crate::tests_common::TmpStorage;

--- a/storage/src/operations_meta_storage.rs
+++ b/storage/src/operations_meta_storage.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::convert::TryFrom;
 
 use rocksdb::{Cache, ColumnFamilyDescriptor, MergeOperands};
 
@@ -233,7 +234,7 @@ impl Decoder for Meta {
             );
             // chain_id
             let chain_id_pos = level_pos + std::mem::size_of::<i32>();
-            let chain_id = bytes[chain_id_pos..chain_id_pos + HashType::ChainId.size()].to_vec();
+            let chain_id = ChainId::try_from(&bytes[chain_id_pos..chain_id_pos + HashType::ChainId.size()])?;
             Ok(Meta {
                 validation_passes,
                 is_validation_pass_present,
@@ -255,7 +256,7 @@ impl Encoder for Meta {
             value.extend(&self.is_validation_pass_present);
             value.push(self.is_complete as u8);
             value.extend(&self.level.to_be_bytes());
-            value.extend(&self.chain_id);
+            value.extend(self.chain_id.as_ref());
             assert_eq!(
                 expected_data_length(self.validation_passes),
                 value.len(),
@@ -281,16 +282,21 @@ fn expected_data_length(validation_passes: u8) -> usize {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{convert::TryInto, path::Path};
 
     use failure::Error;
 
-    use crypto::hash::HashType;
 
     use crate::persistent::{open_kv, DbConfiguration};
     use crate::tests_common::TmpStorage;
 
     use super::*;
+
+    fn block_hash(bytes: &[u8]) -> BlockHash {
+        let mut vec = bytes.to_vec();
+        vec.extend(std::iter::repeat(0).take(HashType::BlockHash.size() - bytes.len()));
+        vec.try_into().unwrap()
+    }
 
     #[test]
     fn operations_meta_encoded_equals_decoded() -> Result<(), Error> {
@@ -299,7 +305,7 @@ mod tests {
             is_complete: false,
             validation_passes: 5,
             level: 93_422,
-            chain_id: vec![44; 4],
+            chain_id: vec![44; 4].try_into()?,
         };
         let encoded_bytes = expected.encode()?;
         let decoded = Meta::decode(&encoded_bytes)?;
@@ -311,9 +317,8 @@ mod tests {
     fn genesis_ops_initialized_success() -> Result<(), Error> {
         let tmp_storage = TmpStorage::create("__opmeta_genesistest")?;
 
-        let k = HashType::BlockHash
-            .b58check_to_hash("BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe")?;
-        let v = Meta::genesis_meta(&vec![44; 4]);
+        let k = "BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe".try_into()?;
+        let v = Meta::genesis_meta(&vec![44; 4].try_into()?);
         let storage = OperationsMetaStorage::new(tmp_storage.storage());
         storage.put(&k, &v)?;
         match storage.get(&k)? {
@@ -323,7 +328,7 @@ mod tests {
                     is_validation_pass_present: vec![],
                     is_complete: true,
                     level: 0,
-                    chain_id: vec![44; 4],
+                    chain_id: vec![44; 4].try_into()?,
                 };
                 assert_eq!(expected, value);
             }
@@ -340,13 +345,13 @@ mod tests {
         let t = true as u8;
         let f = false as u8;
 
-        let k = vec![3, 1, 3, 3, 7];
+        let k = block_hash(&[3, 1, 3, 3, 7]);
         let mut v = Meta {
             is_complete: false,
             is_validation_pass_present: vec![f; 5],
             validation_passes: 5,
             level: 785,
-            chain_id: vec![44; 4],
+            chain_id: vec![44; 4].try_into()?,
         };
         let storage = OperationsMetaStorage::new(tmp_storage.storage());
         storage.put(&k, &v)?;
@@ -364,7 +369,8 @@ mod tests {
                 assert_eq!(vec![f, f, t, t, f], value.is_validation_pass_present);
                 assert!(value.is_complete);
                 assert_eq!(785, value.level);
-                assert_eq!(vec![44; 4], value.chain_id);
+                let ci: ChainId = vec![44; 4].try_into()?;
+                assert_eq!(ci, value.chain_id);
             }
             _ => panic!("value not present"),
         }
@@ -391,13 +397,13 @@ mod tests {
                 vec![OperationsMetaStorage::descriptor(&cache)],
                 &DbConfiguration::default(),
             )?;
-            let k = vec![3, 1, 3, 3, 7];
+            let k = block_hash(&[3, 1, 3, 3, 7]);
             let mut v = Meta {
                 is_complete: false,
                 is_validation_pass_present: vec![f; 5],
                 validation_passes: 5,
                 level: 31_337,
-                chain_id: vec![44; 4],
+                chain_id: vec![44; 4].try_into()?,
             };
             let p = OperationsMetaStorageKV::merge(&db, &k, &v);
             assert!(p.is_ok(), "p: {:?}", p.unwrap_err());
@@ -416,7 +422,8 @@ mod tests {
                     assert_eq!(vec![f, f, t, t, f], value.is_validation_pass_present);
                     assert!(value.is_complete);
                     assert_eq!(31_337, value.level);
-                    assert_eq!(vec![44; 4], value.chain_id);
+                    let chain_id: ChainId = vec![44; 4].try_into()?;
+                    assert_eq!(chain_id, value.chain_id);
                 }
                 Err(_) => println!("error reading value"),
                 _ => panic!("value not present"),
@@ -430,16 +437,16 @@ mod tests {
     fn operations_meta_storage_test_contains() -> Result<(), Error> {
         let tmp_storage = TmpStorage::create("__opmeta_storage_test_contains")?;
 
-        let k = vec![3, 1, 3, 3, 7];
+        let k = block_hash(&[3, 1, 3, 3, 7]);
         let v = Meta {
             is_complete: false,
             is_validation_pass_present: vec![false as u8; 5],
             validation_passes: 5,
             level: 785,
-            chain_id: vec![44; 4],
+            chain_id: vec![44; 4].try_into()?,
         };
-        let k_missing_1 = vec![0, 1, 2];
-        let k_added_later = vec![6, 7, 8, 9];
+        let k_missing_1 = block_hash(&[0, 1, 2]);
+        let k_added_later = block_hash(&[6, 7, 8, 9]);
 
         let storage = OperationsMetaStorage::new(tmp_storage.storage());
         assert!(!storage.contains(&k)?);

--- a/storage/src/operations_storage.rs
+++ b/storage/src/operations_storage.rs
@@ -1,8 +1,8 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::sync::Arc;
 use std::convert::TryFrom;
+use std::sync::Arc;
 
 use rocksdb::{Cache, ColumnFamilyDescriptor, SliceTransform};
 

--- a/storage/src/operations_storage.rs
+++ b/storage/src/operations_storage.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use std::sync::Arc;
+use std::convert::TryFrom;
 
 use rocksdb::{Cache, ColumnFamilyDescriptor, SliceTransform};
 
@@ -138,7 +139,7 @@ impl Decoder for OperationKey {
     #[inline]
     fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
         Ok(OperationKey {
-            block_hash: bytes[0..HashType::BlockHash.size()].to_vec(),
+            block_hash: BlockHash::try_from(&bytes[0..HashType::BlockHash.size()])?,
             validation_pass: bytes[HashType::BlockHash.size()],
         })
     }
@@ -148,7 +149,7 @@ impl Encoder for OperationKey {
     #[inline]
     fn encode(&self) -> Result<Vec<u8>, SchemaError> {
         let mut value = Vec::with_capacity(HashType::BlockHash.size() + 1);
-        value.extend(&self.block_hash);
+        value.extend(self.block_hash.as_ref());
         value.push(self.validation_pass);
         Ok(value)
     }
@@ -170,17 +171,16 @@ impl Encoder for OperationsForBlocksMessage {
 
 #[cfg(test)]
 mod tests {
-    use failure::Error;
+    use std::convert::TryInto;
 
-    use crypto::hash::HashType;
+    use failure::Error;
 
     use super::*;
 
     #[test]
     fn operations_key_encoded_equals_decoded() -> Result<(), Error> {
         let expected = OperationKey {
-            block_hash: HashType::BlockHash
-                .b58check_to_hash("BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET")?,
+            block_hash: "BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET".try_into()?,
             validation_pass: 4,
         };
         let encoded_bytes = expected.encode()?;

--- a/storage/src/persistent/codec.rs
+++ b/storage/src/persistent/codec.rs
@@ -54,20 +54,19 @@ impl Decoder for Hash {
 }
 
 macro_rules! hash_codec {
-	($hash:ident) => {
-		impl Encoder for $hash{
-            fn encode(&self)-> Result<Vec<u8>, SchemaError> {
+    ($hash:ident) => {
+        impl Encoder for $hash {
+            fn encode(&self) -> Result<Vec<u8>, SchemaError> {
                 Ok(self.as_ref().clone())
             }
         }
-        impl Decoder for $hash  {
+        impl Decoder for $hash {
             fn decode(bytes: &[u8]) -> Result<Self, SchemaError> {
                 use std::convert::TryFrom;
                 Self::try_from(bytes).map_err(|_| SchemaError::DecodeError)
             }
         }
-
-	};
+    };
 }
 
 hash_codec!(ChainId);

--- a/storage/src/system_storage.rs
+++ b/storage/src/system_storage.rs
@@ -37,17 +37,22 @@ impl SystemStorage {
     #[inline]
     pub fn get_chain_id(&self) -> Result<Option<ChainId>, StorageError> {
         use std::convert::TryFrom;
-        match self.kv
+        match self
+            .kv
             .get(&Self::CHAIN_ID.to_string())
-            .map(|result| match result {
-                Some(SystemValue::Hash(value)) => Some(ChainId::try_from(value)),
-                _ => None,
-            }.map_or(Ok(None), |r| r.map(Some).map_err(StorageError::from)))
-            .map_err(StorageError::from) {
-                Ok(Err(e)) => Err(e),
-                Ok(Ok(o)) => Ok(o),
-                Err(e) => Err(e),
-            }
+            .map(|result| {
+                match result {
+                    Some(SystemValue::Hash(value)) => Some(ChainId::try_from(value)),
+                    _ => None,
+                }
+                .map_or(Ok(None), |r| r.map(Some).map_err(StorageError::from))
+            })
+            .map_err(StorageError::from)
+        {
+            Ok(Err(e)) => Err(e),
+            Ok(Ok(o)) => Ok(o),
+            Err(e) => Err(e),
+        }
     }
 
     #[inline]

--- a/storage/src/system_storage.rs
+++ b/storage/src/system_storage.rs
@@ -36,13 +36,18 @@ impl SystemStorage {
 
     #[inline]
     pub fn get_chain_id(&self) -> Result<Option<ChainId>, StorageError> {
-        self.kv
+        use std::convert::TryFrom;
+        match self.kv
             .get(&Self::CHAIN_ID.to_string())
             .map(|result| match result {
-                Some(SystemValue::Hash(value)) => Some(value),
+                Some(SystemValue::Hash(value)) => Some(ChainId::try_from(value)),
                 _ => None,
-            })
-            .map_err(StorageError::from)
+            }.map_or(Ok(None), |r| r.map(Some).map_err(StorageError::from)))
+            .map_err(StorageError::from) {
+                Ok(Err(e)) => Err(e),
+                Ok(Ok(o)) => Ok(o),
+                Err(e) => Err(e),
+            }
     }
 
     #[inline]
@@ -50,7 +55,7 @@ impl SystemStorage {
         self.kv
             .put(
                 &Self::CHAIN_ID.to_string(),
-                &SystemValue::Hash(chain_id.clone()),
+                &SystemValue::Hash(chain_id.clone().into()),
             )
             .map_err(StorageError::from)
     }

--- a/storage/tests/block_header_with_hash.rs
+++ b/storage/tests/block_header_with_hash.rs
@@ -17,18 +17,14 @@ fn block_header_with_hash_encoded_equals_decoded() -> Result<(), Error> {
             BlockHeaderBuilder::default()
                 .level(34)
                 .proto(1)
-                .predecessor(
-                    "BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET".try_into()?,
-                )
+                .predecessor("BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET".try_into()?)
                 .timestamp(5_635_634)
                 .validation_pass(4)
                 .operations_hash(
-                        "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc".try_into()?
+                    "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc".try_into()?,
                 )
                 .fitness(vec![vec![0, 0]])
-                .context(
-                    "CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd".try_into()?,
-                )
+                .context("CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd".try_into()?)
                 .protocol_data(vec![0, 1, 2, 3, 4, 5, 6, 7, 8])
                 .build()
                 .unwrap(),

--- a/storage/tests/block_header_with_hash.rs
+++ b/storage/tests/block_header_with_hash.rs
@@ -1,11 +1,10 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::sync::Arc;
+use std::{convert::TryInto, sync::Arc};
 
 use failure::Error;
 
-use crypto::hash::HashType;
 use storage::persistent::{Decoder, Encoder};
 use storage::BlockHeaderWithHash;
 use tezos_messages::p2p::encoding::prelude::BlockHeaderBuilder;
@@ -13,27 +12,22 @@ use tezos_messages::p2p::encoding::prelude::BlockHeaderBuilder;
 #[test]
 fn block_header_with_hash_encoded_equals_decoded() -> Result<(), Error> {
     let expected = BlockHeaderWithHash {
-        hash: HashType::BlockHash
-            .b58check_to_hash("BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET")?,
+        hash: "BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET".try_into()?,
         header: Arc::new(
             BlockHeaderBuilder::default()
                 .level(34)
                 .proto(1)
                 .predecessor(
-                    HashType::BlockHash
-                        .b58check_to_hash("BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET")?,
+                    "BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET".try_into()?,
                 )
                 .timestamp(5_635_634)
                 .validation_pass(4)
                 .operations_hash(
-                    HashType::OperationListListHash.b58check_to_hash(
-                        "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc",
-                    )?,
+                        "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc".try_into()?
                 )
                 .fitness(vec![vec![0, 0]])
                 .context(
-                    HashType::ContextHash
-                        .b58check_to_hash("CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd")?,
+                    "CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd".try_into()?,
                 )
                 .protocol_data(vec![0, 1, 2, 3, 4, 5, 6, 7, 8])
                 .build()

--- a/storage/tests/block_storage.rs
+++ b/storage/tests/block_storage.rs
@@ -1,6 +1,8 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use std::convert::TryInto;
+
 use failure::Error;
 
 use crypto::hash::HashType;
@@ -61,7 +63,7 @@ fn block_storage_assign_context() -> Result<(), Error> {
     let storage = BlockStorage::new(tmp_storage.storage());
 
     let block_header = make_test_block_header()?;
-    let context_hash = vec![1; HashType::ContextHash.size()];
+    let context_hash = vec![1; HashType::ContextHash.size()].try_into()?;
 
     storage.put_block_header(&block_header)?;
     storage.assign_to_context(&block_header.hash, &context_hash)?;

--- a/storage/tests/context.rs
+++ b/storage/tests/context.rs
@@ -1,11 +1,11 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::env;
+use std::{convert::{TryFrom, TryInto}, env};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crypto::hash::{ContextHash, HashType};
+use crypto::hash::ContextHash;
 use storage::context::{ContextApi, TezedgeContext};
 use storage::tests_common::TmpStorage;
 use storage::{context_key, BlockHeaderWithHash, BlockStorage};
@@ -39,8 +39,8 @@ pub fn test_context_set_get_commit() -> Result<(), failure::Error> {
     )?;
 
     // commit
-    let new_context_hash: ContextHash = HashType::ContextHash
-        .b58check_to_hash("CoVf53zSDGcSWS74Mxe2i2RJnVfCaMrAjxK2Xq7tgiFMtkNwUdPv")?;
+    let new_context_hash =
+        ContextHash::try_from("CoVf53zSDGcSWS74Mxe2i2RJnVfCaMrAjxK2Xq7tgiFMtkNwUdPv")?;
 
     let hash = context.commit(
         &block.hash,
@@ -115,8 +115,7 @@ pub fn test_context_delete_and_remove() -> Result<(), failure::Error> {
     )?;
 
     // commit
-    let context_hash_1: ContextHash = HashType::ContextHash
-        .b58check_to_hash("CoUyfscSjC3XYECq1aFYQQLrVZuNSW17B7SbFDV9W1REfhJpxZwB")?;
+    let context_hash_1: ContextHash = "CoUyfscSjC3XYECq1aFYQQLrVZuNSW17B7SbFDV9W1REfhJpxZwB".try_into()?;
 
     let hash = context.commit(
         &block.hash,
@@ -184,8 +183,7 @@ pub fn test_context_delete_and_remove() -> Result<(), failure::Error> {
     )?;
 
     // commit
-    let context_hash_2: ContextHash = HashType::ContextHash
-        .b58check_to_hash("CoVGom58bpVjHWVsKuc8k7JC7QyzZ7n4ntGZiPpw2CwM43sxC4XF")?;
+    let context_hash_2: ContextHash = "CoVGom58bpVjHWVsKuc8k7JC7QyzZ7n4ntGZiPpw2CwM43sxC4XF".try_into()?;
 
     let hash = context.commit(
         &block.hash,
@@ -280,8 +278,7 @@ pub fn test_context_copy() -> Result<(), failure::Error> {
     )?;
 
     // commit
-    let context_hash_1: ContextHash = HashType::ContextHash
-        .b58check_to_hash("CoVu1KaQQd2SFPqJh7go1t9q11upv1BewzShtTrNK7ZF6uCAcUQR")?;
+    let context_hash_1: ContextHash = "CoVu1KaQQd2SFPqJh7go1t9q11upv1BewzShtTrNK7ZF6uCAcUQR".try_into()?;
 
     let hash = context.commit(
         &block.hash,
@@ -340,8 +337,7 @@ pub fn test_context_copy() -> Result<(), failure::Error> {
     )?;
 
     // commit
-    let context_hash_2: ContextHash = HashType::ContextHash
-        .b58check_to_hash("CoVX1ptKigdesVSqaREXTTHKGegLGM4x1bSSFvPgX5V8qj85r98G")?;
+    let context_hash_2: ContextHash = "CoVX1ptKigdesVSqaREXTTHKGegLGM4x1bSSFvPgX5V8qj85r98G".try_into()?;
 
     let hash = context.commit(
         &block.hash,
@@ -421,27 +417,19 @@ pub fn test_context_copy() -> Result<(), failure::Error> {
 
 fn dummy_block(block_hash: &str, level: i32) -> Result<BlockHeaderWithHash, failure::Error> {
     Ok(BlockHeaderWithHash {
-        hash: HashType::BlockHash.b58check_to_hash(block_hash)?,
+        hash: block_hash.try_into()?,
         header: Arc::new(
             BlockHeaderBuilder::default()
                 .level(level)
                 .proto(0)
                 .predecessor(
-                    HashType::BlockHash
-                        .b58check_to_hash("BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe")?,
+                    "BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe".try_into()?,
                 )
                 .timestamp(5_635_634)
                 .validation_pass(0)
-                .operations_hash(
-                    HashType::OperationListListHash.b58check_to_hash(
-                        "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc",
-                    )?,
-                )
+                .operations_hash("LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc".try_into()?)
                 .fitness(vec![])
-                .context(
-                    HashType::ContextHash
-                        .b58check_to_hash("CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd")?,
-                )
+                .context("CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd".try_into()?)
                 .protocol_data(vec![])
                 .build()
                 .unwrap(),

--- a/storage/tests/context.rs
+++ b/storage/tests/context.rs
@@ -1,9 +1,12 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::{convert::{TryFrom, TryInto}, env};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::{
+    convert::{TryFrom, TryInto},
+    env,
+};
 
 use crypto::hash::ContextHash;
 use storage::context::{ContextApi, TezedgeContext};
@@ -115,7 +118,8 @@ pub fn test_context_delete_and_remove() -> Result<(), failure::Error> {
     )?;
 
     // commit
-    let context_hash_1: ContextHash = "CoUyfscSjC3XYECq1aFYQQLrVZuNSW17B7SbFDV9W1REfhJpxZwB".try_into()?;
+    let context_hash_1: ContextHash =
+        "CoUyfscSjC3XYECq1aFYQQLrVZuNSW17B7SbFDV9W1REfhJpxZwB".try_into()?;
 
     let hash = context.commit(
         &block.hash,
@@ -183,7 +187,8 @@ pub fn test_context_delete_and_remove() -> Result<(), failure::Error> {
     )?;
 
     // commit
-    let context_hash_2: ContextHash = "CoVGom58bpVjHWVsKuc8k7JC7QyzZ7n4ntGZiPpw2CwM43sxC4XF".try_into()?;
+    let context_hash_2: ContextHash =
+        "CoVGom58bpVjHWVsKuc8k7JC7QyzZ7n4ntGZiPpw2CwM43sxC4XF".try_into()?;
 
     let hash = context.commit(
         &block.hash,
@@ -278,7 +283,8 @@ pub fn test_context_copy() -> Result<(), failure::Error> {
     )?;
 
     // commit
-    let context_hash_1: ContextHash = "CoVu1KaQQd2SFPqJh7go1t9q11upv1BewzShtTrNK7ZF6uCAcUQR".try_into()?;
+    let context_hash_1: ContextHash =
+        "CoVu1KaQQd2SFPqJh7go1t9q11upv1BewzShtTrNK7ZF6uCAcUQR".try_into()?;
 
     let hash = context.commit(
         &block.hash,
@@ -337,7 +343,8 @@ pub fn test_context_copy() -> Result<(), failure::Error> {
     )?;
 
     // commit
-    let context_hash_2: ContextHash = "CoVX1ptKigdesVSqaREXTTHKGegLGM4x1bSSFvPgX5V8qj85r98G".try_into()?;
+    let context_hash_2: ContextHash =
+        "CoVX1ptKigdesVSqaREXTTHKGegLGM4x1bSSFvPgX5V8qj85r98G".try_into()?;
 
     let hash = context.commit(
         &block.hash,
@@ -422,12 +429,12 @@ fn dummy_block(block_hash: &str, level: i32) -> Result<BlockHeaderWithHash, fail
             BlockHeaderBuilder::default()
                 .level(level)
                 .proto(0)
-                .predecessor(
-                    "BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe".try_into()?,
-                )
+                .predecessor("BLockGenesisGenesisGenesisGenesisGenesisb83baZgbyZe".try_into()?)
                 .timestamp(5_635_634)
                 .validation_pass(0)
-                .operations_hash("LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc".try_into()?)
+                .operations_hash(
+                    "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc".try_into()?,
+                )
                 .fitness(vec![])
                 .context("CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd".try_into()?)
                 .protocol_data(vec![])

--- a/storage/tests/context_action_storage.rs
+++ b/storage/tests/context_action_storage.rs
@@ -1,9 +1,10 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use std::convert::TryInto;
+
 use failure::Error;
 
-use crypto::hash::HashType;
 use storage::tests_common::TmpStorage;
 use storage::*;
 use tezos_context::channel::ContextAction;
@@ -13,9 +14,9 @@ fn context_get_values_by_block_hash() -> Result<(), Error> {
     let tmp_storage = TmpStorage::create("__ctx_storage_get_by_block_hash")?;
 
     let str_block_hash_1 = "BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET";
-    let block_hash_1 = HashType::BlockHash.b58check_to_hash(str_block_hash_1)?;
+    let block_hash_1 = str_block_hash_1.try_into()?;
     let str_block_hash_2 = "BLaf78njreWdt2WigJjM9e3ecEdVKm5ehahUfYBKvcWvZ8vfTcJ";
-    let block_hash_2 = HashType::BlockHash.b58check_to_hash(str_block_hash_2)?;
+    let block_hash_2 = str_block_hash_2.try_into()?;
     let value_1_0 = ContextAction::Set {
         key: vec![
             "hello".to_string(),
@@ -118,7 +119,7 @@ fn context_get_values_by_contract_address() -> Result<(), Error> {
     let tmp_storage = TmpStorage::create("__ctx_storage_get_by_contract_address")?;
 
     let str_block_hash = "BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET";
-    let block_hash = HashType::BlockHash.b58check_to_hash(str_block_hash)?;
+    let block_hash = str_block_hash.try_into()?;
     let value = ContextAction::Set {
         key: vec![
             "data".to_string(),

--- a/storage/tests/mempool_storage.rs
+++ b/storage/tests/mempool_storage.rs
@@ -3,6 +3,7 @@
 
 use std::time::SystemTime;
 
+use crypto::hash::OperationHash;
 use failure::Error;
 
 use storage::mempool_storage::MempoolOperationType;
@@ -18,7 +19,7 @@ fn mempool_storage_read_write() -> Result<(), Error> {
     let mut storage = MempoolStorage::new(tmp_storage.storage());
 
     let operation = make_test_operation_message()?;
-    let operation_hash = operation.message_hash()?.clone();
+    let operation_hash = operation.message_typed_hash::<OperationHash>()?;
     let ttl = SystemTime::now();
 
     storage.put_known_valid(operation.clone(), ttl)?;

--- a/storage/tests/operations_storage.rs
+++ b/storage/tests/operations_storage.rs
@@ -1,9 +1,11 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use std::convert::TryFrom;
+
+use crypto::hash::BlockHash;
 use failure::Error;
 
-use crypto::hash::HashType;
 use storage::tests_common::TmpStorage;
 use storage::*;
 use tezos_messages::p2p::encoding::prelude::*;
@@ -12,12 +14,9 @@ use tezos_messages::p2p::encoding::prelude::*;
 fn test_get_operations() -> Result<(), Error> {
     let tmp_storage = TmpStorage::create("__op_storage_get_operations")?;
 
-    let block_hash_1 = HashType::BlockHash
-        .b58check_to_hash("BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET")?;
-    let block_hash_2 = HashType::BlockHash
-        .b58check_to_hash("BLaf78njreWdt2WigJjM9e3ecEdVKm5ehahUfYBKvcWvZ8vfTcJ")?;
-    let block_hash_3 = HashType::BlockHash
-        .b58check_to_hash("BKzyxvaMgoY5M3BUD7UaUCPivAku2NRiYRA1z1LQUzB7CX6e8yy")?;
+    let block_hash_1 = BlockHash::try_from("BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET")?;
+    let block_hash_2 = BlockHash::try_from("BLaf78njreWdt2WigJjM9e3ecEdVKm5ehahUfYBKvcWvZ8vfTcJ")?;
+    let block_hash_3 = BlockHash::try_from("BKzyxvaMgoY5M3BUD7UaUCPivAku2NRiYRA1z1LQUzB7CX6e8yy")?;
 
     let storage = OperationsStorage::new(tmp_storage.storage());
     let message = OperationsForBlocksMessage::new(

--- a/storage/tests/storage_for_shell.rs
+++ b/storage/tests/storage_for_shell.rs
@@ -1,13 +1,16 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::{convert::{TryFrom, TryInto}, env};
 use std::path::{Path, PathBuf};
+use std::{
+    convert::{TryFrom, TryInto},
+    env,
+};
 
 use failure::Error;
 use slog::{Drain, Level, Logger};
 
-use crypto::hash::{BlockHash, ContextHash, chain_id_from_block_hash};
+use crypto::hash::{chain_id_from_block_hash, BlockHash, ContextHash};
 use storage::chain_meta_storage::ChainMetaStorageReader;
 use storage::tests_common::TmpStorage;
 use storage::*;
@@ -168,7 +171,9 @@ fn test_storage() -> Result<(), Error> {
     let apply_result = ApplyBlockResponse {
         last_allowed_fork_level: 5,
         max_operations_ttl: 6,
-        context_hash: ContextHash::from_base58_check("CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd")?,
+        context_hash: ContextHash::from_base58_check(
+            "CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd",
+        )?,
         block_header_proto_json: "{block_header_proto_json}".to_string(),
         block_header_proto_metadata_json: "{block_header_proto_metadata_json}".to_string(),
         operations_proto_metadata_json: "{operations_proto_metadata_json}".to_string(),

--- a/storage/tests/storage_for_shell.rs
+++ b/storage/tests/storage_for_shell.rs
@@ -1,13 +1,13 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::env;
+use std::{convert::{TryFrom, TryInto}, env};
 use std::path::{Path, PathBuf};
 
 use failure::Error;
 use slog::{Drain, Level, Logger};
 
-use crypto::hash::{chain_id_from_block_hash, ContextHash, HashType};
+use crypto::hash::{BlockHash, ContextHash, chain_id_from_block_hash};
 use storage::chain_meta_storage::ChainMetaStorageReader;
 use storage::tests_common::TmpStorage;
 use storage::*;
@@ -59,11 +59,11 @@ fn test_storage() -> Result<(), Error> {
     let init_data = init_data.unwrap();
     assert_eq!(
         init_data.genesis_block_header_hash,
-        HashType::BlockHash.b58check_to_hash(&tezos_env.genesis.block)?
+        BlockHash::try_from(tezos_env.genesis.block.as_str())?
     );
     assert_eq!(
         init_data.chain_id,
-        chain_id_from_block_hash(&HashType::BlockHash.b58check_to_hash(&tezos_env.genesis.block)?)
+        chain_id_from_block_hash(&BlockHash::try_from(tezos_env.genesis.block.as_str())?)
     );
 
     // load current head (non)
@@ -76,8 +76,7 @@ fn test_storage() -> Result<(), Error> {
     assert!(genesis.is_none());
 
     // simulate commit genesis in two steps
-    let new_context_hash: ContextHash = HashType::ContextHash
-        .b58check_to_hash("CoV16kW8WgL51SpcftQKdeqc94D6ekghMgPMmEn7TSZzFA697PeE")?;
+    let new_context_hash = "CoV16kW8WgL51SpcftQKdeqc94D6ekghMgPMmEn7TSZzFA697PeE".try_into()?;
     let _ = initialize_storage_with_genesis_block(
         &block_storage,
         &init_data,
@@ -169,8 +168,7 @@ fn test_storage() -> Result<(), Error> {
     let apply_result = ApplyBlockResponse {
         last_allowed_fork_level: 5,
         max_operations_ttl: 6,
-        context_hash: HashType::ContextHash
-            .b58check_to_hash("CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd")?,
+        context_hash: ContextHash::from_base58_check("CoVmAcMV64uAQo8XvfLr9VDuz7HVZLT4cgK1w1qYmTjQNbGwQwDd")?,
         block_header_proto_json: "{block_header_proto_json}".to_string(),
         block_header_proto_metadata_json: "{block_header_proto_metadata_json}".to_string(),
         operations_proto_metadata_json: "{operations_proto_metadata_json}".to_string(),

--- a/tezos/api/src/environment.rs
+++ b/tezos/api/src/environment.rs
@@ -1,8 +1,11 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::{collections::HashMap, convert::{TryFrom, TryInto}};
 use std::str::FromStr;
+use std::{
+    collections::HashMap,
+    convert::{TryFrom, TryInto},
+};
 
 use chrono::prelude::*;
 use chrono::ParseError;
@@ -13,8 +16,7 @@ use serde::{Deserialize, Serialize};
 
 use crypto::base58::FromBase58CheckError;
 use crypto::hash::{
-    chain_id_from_block_hash, BlockHash, ChainId, ContextHash, OperationListListHash,
-    ProtocolHash,
+    chain_id_from_block_hash, BlockHash, ChainId, ContextHash, OperationListListHash, ProtocolHash,
 };
 use tezos_messages::p2p::encoding::prelude::{BlockHeader, BlockHeaderBuilder};
 
@@ -311,11 +313,12 @@ pub struct TezosEnvironmentConfiguration {
 impl TezosEnvironmentConfiguration {
     /// Resolves genesis hash from configuration of GenesisChain.block
     pub fn genesis_header_hash(&self) -> Result<BlockHash, TezosEnvironmentError> {
-        BlockHash::from_base58_check(&self.genesis.block)
-            .map_err(|e| TezosEnvironmentError::InvalidBlockHash {
+        BlockHash::from_base58_check(&self.genesis.block).map_err(|e| {
+            TezosEnvironmentError::InvalidBlockHash {
                 hash: self.genesis.block.clone(),
                 error: e,
-            })
+            }
+        })
     }
 
     /// Resolves main chain_id, which is computed from genesis header
@@ -325,11 +328,12 @@ impl TezosEnvironmentConfiguration {
 
     /// Resolves genesis protocol
     pub fn genesis_protocol(&self) -> Result<ProtocolHash, TezosEnvironmentError> {
-        self.genesis.protocol.as_str().try_into()
-            .map_err(|e| TezosEnvironmentError::InvalidProtocolHash {
+        self.genesis.protocol.as_str().try_into().map_err(|e| {
+            TezosEnvironmentError::InvalidProtocolHash {
                 hash: self.genesis.protocol.clone(),
                 error: e,
-            })
+            }
+        })
     }
 
     pub fn genesis_time(&self) -> Result<i64, TezosEnvironmentError> {

--- a/tezos/api/src/ffi.rs
+++ b/tezos/api/src/ffi.rs
@@ -10,10 +10,7 @@ use failure::Fail;
 use ocaml_interop::OCamlError;
 use serde::{Deserialize, Serialize};
 
-use crypto::hash::{
-    BlockHash, BlockMetadataHash, ChainId, ContextHash, HashType, OperationHash,
-    OperationMetadataHash, OperationMetadataListListHash, ProtocolHash,
-};
+use crypto::hash::{BlockHash, BlockMetadataHash, ChainId, ContextHash, FromBytesError, OperationHash, OperationMetadataHash, OperationMetadataListListHash, ProtocolHash};
 use tezos_messages::base::rpc_support::{RpcJsonMap, UniversalValue};
 use tezos_messages::p2p::binary_message::{MessageHash, MessageHashError};
 use tezos_messages::p2p::encoding::block_header::{display_fitness, Fitness};
@@ -155,8 +152,8 @@ impl fmt::Debug for PrevalidatorWrapper {
         write!(
             f,
             "PrevalidatorWrapper[chain_id: {}, protocol: {}, context_fitness: {}]",
-            HashType::ChainId.hash_to_b58check(&self.chain_id),
-            HashType::ProtocolHash.hash_to_b58check(&self.protocol),
+            self.chain_id.to_base58_check(),
+            self.protocol.to_base58_check(),
             match &self.context_fitness {
                 Some(fitness) => display_fitness(fitness),
                 None => "-none-".to_string(),
@@ -236,7 +233,7 @@ impl fmt::Debug for Applied {
         write!(
             f,
             "[hash: {}, protocol_data_json: {}]",
-            HashType::OperationHash.hash_to_b58check(&self.hash),
+            self.hash.to_base58_check(),
             &self.protocol_data_json
         )
     }
@@ -260,7 +257,7 @@ impl fmt::Debug for Errored {
         write!(
             f,
             "[hash: {}, protocol_data_json_with_error_json: {:?}]",
-            HashType::OperationHash.hash_to_b58check(&self.hash),
+            self.hash.to_base58_check(),
             &self.protocol_data_json_with_error_json
         )
     }
@@ -325,13 +322,13 @@ pub struct InitProtocolContextResult {
 impl fmt::Debug for InitProtocolContextResult {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let genesis_commit_hash = match &self.genesis_commit_hash {
-            Some(hash) => HashType::ContextHash.hash_to_b58check(hash),
+            Some(hash) => hash.to_base58_check(),
             None => "-none-".to_string(),
         };
         let supported_protocol_hashes = self
             .supported_protocol_hashes
             .iter()
-            .map(|ph| HashType::ProtocolHash.hash_to_b58check(ph))
+            .map(|ph| ph.to_base58_check())
             .collect::<Vec<String>>();
         write!(
             f,
@@ -413,6 +410,14 @@ impl From<OCamlError> for TezosStorageInitError {
             OCamlError::Exception(exception) => TezosStorageInitError::InitializeError {
                 message: exception.message().unwrap_or_else(|| "unknown".to_string()),
             },
+        }
+    }
+}
+
+impl From<FromBytesError> for TezosStorageInitError {
+    fn from(error: FromBytesError) -> Self {
+        TezosStorageInitError::InitializeError {
+            message: format!("Error constructing hash from bytes: {:?}", error)
         }
     }
 }
@@ -653,6 +658,14 @@ impl From<OCamlError> for ProtocolDataError {
     }
 }
 
+impl From<FromBytesError> for ProtocolDataError {
+    fn from(error: FromBytesError) -> Self {
+        ProtocolDataError::DecodeError {
+            message: format!("Error constructing hash from bytes: {:?}", error),
+        }
+    }
+}
+
 pub type Json = String;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -794,7 +807,7 @@ impl TryFrom<&Vec<Vec<Operation>>> for ComputePathRequest {
         for inner_ops in ops {
             let mut iophs = Vec::with_capacity(inner_ops.len());
             for op in inner_ops {
-                iophs.push(op.message_hash()?);
+                iophs.push(OperationHash::try_from(op.message_hash()?)?);
             }
             operation_hashes.push(iophs);
         }
@@ -841,6 +854,8 @@ impl From<CallError> for ComputePathError {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::TryInto;
+
     use assert_json_diff::assert_json_eq;
 
     use super::*;
@@ -900,8 +915,7 @@ mod tests {
         assert!(ValidateOperationResult::merge_items(
             &mut validate_result.applied,
             vec![Applied {
-                hash: HashType::OperationHash
-                    .b58check_to_hash("onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ")?,
+                hash: "onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ".try_into()?,
                 protocol_data_json: "protocol_data_json1".to_string(),
             },],
         ));
@@ -915,8 +929,7 @@ mod tests {
         assert!(ValidateOperationResult::merge_items(
             &mut validate_result.applied,
             vec![Applied {
-                hash: HashType::OperationHash
-                    .b58check_to_hash("onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ")?,
+                hash: "onvN8U6QJ6DGJKVYkHXYRtFm3tgBJScj9P5bbPjSZUuFaGzwFuJ".try_into()?,
                 protocol_data_json: "protocol_data_json2".to_string(),
             },],
         ));
@@ -930,8 +943,7 @@ mod tests {
         assert!(ValidateOperationResult::merge_items(
             &mut validate_result.applied,
             vec![Applied {
-                hash: HashType::OperationHash
-                    .b58check_to_hash("opJ4FdKumPfykAP9ZqwY7rNB8y1SiMupt44RqBDMWL7cmb4xbNr")?,
+                hash: "opJ4FdKumPfykAP9ZqwY7rNB8y1SiMupt44RqBDMWL7cmb4xbNr".try_into()?,
                 protocol_data_json: "protocol_data_json2".to_string(),
             },],
         ));
@@ -943,18 +955,18 @@ mod tests {
     fn validate_operation_result(op1: &str, op2: &str) -> ValidateOperationResult {
         let applied = vec![
             Applied {
-                hash: HashType::OperationHash.b58check_to_hash(op1).expect("Error"),
+                hash: op1.try_into().expect("Error"),
                 protocol_data_json: "{ \"contents\": [ { \"kind\": \"endorsement\", \"level\": 459020 } ],\n  \"signature\":\n    \"siguKbKFVDkXo2m1DqZyftSGg7GZRq43EVLSutfX5yRLXXfWYG5fegXsDT6EUUqawYpjYE1GkyCVHfc2kr3hcaDAvWSAhnV9\" }".to_string(),
             },
             Applied {
-                hash: HashType::OperationHash.b58check_to_hash(op2).expect("Error"),
+                hash: op2.try_into().expect("Error"),
                 protocol_data_json: "{ \"contents\": [ { \"kind\": \"endorsement\", \"level\": 459020 } ],\n  \"signature\":\n    \"siguKbKFVDkXo2m1DqZyftSGg7GZRq43EVLSutfX5yRLXXfWYG5fegXsDT6EUUqawYpjYE1GkyCVHfc2kr3hcaDAvWSAhnV9\" }".to_string(),
             }
         ];
 
         let branch_delayed = vec![
             Errored {
-                hash: HashType::OperationHash.b58check_to_hash(op1).expect("Error"),
+                hash: op1.try_into().expect("Error"),
                 is_endorsement: None,
                 protocol_data_json_with_error_json: OperationProtocolDataJsonWithErrorListJson {
                     protocol_data_json: "{ \"contents\": [ { \"kind\": \"endorsement\", \"level\": 459020 } ],\n  \"signature\":\n    \"siguKbKFVDkXo2m1DqZyftSGg7GZRq43EVLSutfX5yRLXXfWYG5fegXsDT6EUUqawYpjYE1GkyCVHfc2kr3hcaDAvWSAhnV9\" }".to_string(),
@@ -962,7 +974,7 @@ mod tests {
                 },
             },
             Errored {
-                hash: HashType::OperationHash.b58check_to_hash(op2).expect("Error"),
+                hash: op2.try_into().expect("Error"),
                 is_endorsement: None,
                 protocol_data_json_with_error_json: OperationProtocolDataJsonWithErrorListJson {
                     protocol_data_json: "{ \"contents\": [ { \"kind\": \"endorsement\", \"level\": 459020 } ],\n  \"signature\":\n    \"siguKbKFVDkXo2m1DqZyftSGg7GZRq43EVLSutfX5yRLXXfWYG5fegXsDT6EUUqawYpjYE1GkyCVHfc2kr3hcaDAvWSAhnV9\" }".to_string(),
@@ -973,7 +985,7 @@ mod tests {
 
         let branch_refused = vec![
             Errored {
-                hash: HashType::OperationHash.b58check_to_hash(op1).expect("Error"),
+                hash: op1.try_into().expect("Error"),
                 is_endorsement: None,
                 protocol_data_json_with_error_json: OperationProtocolDataJsonWithErrorListJson {
                     protocol_data_json: "{ \"contents\": [ { \"kind\": \"endorsement\", \"level\": 459020 } ],\n  \"signature\":\n    \"siguKbKFVDkXo2m1DqZyftSGg7GZRq43EVLSutfX5yRLXXfWYG5fegXsDT6EUUqawYpjYE1GkyCVHfc2kr3hcaDAvWSAhnV9\" }".to_string(),
@@ -981,7 +993,7 @@ mod tests {
                 },
             },
             Errored {
-                hash: HashType::OperationHash.b58check_to_hash(op2).expect("Error"),
+                hash: op2.try_into().expect("Error"),
                 is_endorsement: None,
                 protocol_data_json_with_error_json: OperationProtocolDataJsonWithErrorListJson {
                     protocol_data_json: "{ \"contents\": [ { \"kind\": \"endorsement\", \"level\": 459020 } ],\n  \"signature\":\n    \"siguKbKFVDkXo2m1DqZyftSGg7GZRq43EVLSutfX5yRLXXfWYG5fegXsDT6EUUqawYpjYE1GkyCVHfc2kr3hcaDAvWSAhnV9\" }".to_string(),
@@ -992,7 +1004,7 @@ mod tests {
 
         let refused = vec![
             Errored {
-                hash: HashType::OperationHash.b58check_to_hash(op1).expect("Error"),
+                hash: op1.try_into().expect("Error"),
                 is_endorsement: None,
                 protocol_data_json_with_error_json: OperationProtocolDataJsonWithErrorListJson {
                     protocol_data_json: "{ \"contents\": [ { \"kind\": \"endorsement\", \"level\": 459020 } ],\n  \"signature\":\n    \"siguKbKFVDkXo2m1DqZyftSGg7GZRq43EVLSutfX5yRLXXfWYG5fegXsDT6EUUqawYpjYE1GkyCVHfc2kr3hcaDAvWSAhnV9\" }".to_string(),
@@ -1000,7 +1012,7 @@ mod tests {
                 },
             },
             Errored {
-                hash: HashType::OperationHash.b58check_to_hash(op2).expect("Error"),
+                hash: op2.try_into().expect("Error"),
                 is_endorsement: None,
                 protocol_data_json_with_error_json: OperationProtocolDataJsonWithErrorListJson {
                     protocol_data_json: "{ \"contents\": [ { \"kind\": \"endorsement\", \"level\": 459020 } ],\n  \"signature\":\n    \"siguKbKFVDkXo2m1DqZyftSGg7GZRq43EVLSutfX5yRLXXfWYG5fegXsDT6EUUqawYpjYE1GkyCVHfc2kr3hcaDAvWSAhnV9\" }".to_string(),

--- a/tezos/api/src/ffi.rs
+++ b/tezos/api/src/ffi.rs
@@ -10,7 +10,10 @@ use failure::Fail;
 use ocaml_interop::OCamlError;
 use serde::{Deserialize, Serialize};
 
-use crypto::hash::{BlockHash, BlockMetadataHash, ChainId, ContextHash, FromBytesError, OperationHash, OperationMetadataHash, OperationMetadataListListHash, ProtocolHash};
+use crypto::hash::{
+    BlockHash, BlockMetadataHash, ChainId, ContextHash, FromBytesError, OperationHash,
+    OperationMetadataHash, OperationMetadataListListHash, ProtocolHash,
+};
 use tezos_messages::base::rpc_support::{RpcJsonMap, UniversalValue};
 use tezos_messages::p2p::binary_message::{MessageHash, MessageHashError};
 use tezos_messages::p2p::encoding::block_header::{display_fitness, Fitness};
@@ -417,7 +420,7 @@ impl From<OCamlError> for TezosStorageInitError {
 impl From<FromBytesError> for TezosStorageInitError {
     fn from(error: FromBytesError) -> Self {
         TezosStorageInitError::InitializeError {
-            message: format!("Error constructing hash from bytes: {:?}", error)
+            message: format!("Error constructing hash from bytes: {:?}", error),
         }
     }
 }

--- a/tezos/api/src/ocaml_conv/from_ocaml.rs
+++ b/tezos/api/src/ocaml_conv/from_ocaml.rs
@@ -1,6 +1,8 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use std::convert::TryFrom;
+
 use super::{
     FfiPath, OCamlBlockHash, OCamlBlockMetadataHash, OCamlChainId, OCamlContextHash, OCamlHash,
     OCamlOperationHash, OCamlOperationMetadataHash, OCamlOperationMetadataListListHash,
@@ -57,7 +59,14 @@ from_ocaml_typed_hash!(
     OCamlOperationMetadataListListHash,
     OperationMetadataListListHash
 );
-from_ocaml_typed_hash!(OCamlChainId, ChainId);
+
+unsafe impl FromOCaml<OCamlChainId> for ChainId {
+    fn from_ocaml(v: OCaml<OCamlChainId>) -> Self {
+        let v: OCaml<OCamlBytes> = unsafe { std::mem::transmute(v) };
+        let vec: Vec<u8> = v.to_rust();
+        ChainId::try_from(vec).unwrap()
+    }
+}
 
 impl_from_ocaml_record! {
     ForkingTestchainData {

--- a/tezos/api/src/ocaml_conv/from_ocaml.rs
+++ b/tezos/api/src/ocaml_conv/from_ocaml.rs
@@ -1,14 +1,21 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use super::{FfiPath, OCamlBlockHash, OCamlBlockMetadataHash, OCamlChainId, OCamlContextHash, OCamlHash, OCamlOperationHash, OCamlOperationMetadataHash, OCamlOperationMetadataListListHash, OCamlProtocolHash};
+use super::{
+    FfiPath, OCamlBlockHash, OCamlBlockMetadataHash, OCamlChainId, OCamlContextHash, OCamlHash,
+    OCamlOperationHash, OCamlOperationMetadataHash, OCamlOperationMetadataListListHash,
+    OCamlProtocolHash,
+};
 use crate::ffi::{
     Applied, ApplyBlockResponse, BeginApplicationResponse, Errored, ForkingTestchainData,
     HelpersPreapplyResponse, OperationProtocolDataJsonWithErrorListJson, PrevalidatorWrapper,
     ProtocolRpcError, ProtocolRpcResponse, RpcArgDesc, RpcMethod, ValidateOperationResponse,
     ValidateOperationResult,
 };
-use crypto::hash::{BlockHash, BlockMetadataHash, ChainId, ContextHash, Hash, OperationHash, OperationMetadataHash, OperationMetadataListListHash, ProtocolHash};
+use crypto::hash::{
+    BlockHash, BlockMetadataHash, ChainId, ContextHash, Hash, OperationHash, OperationMetadataHash,
+    OperationMetadataListListHash, ProtocolHash,
+};
 use ocaml_interop::{
     impl_from_ocaml_record, impl_from_ocaml_variant, FromOCaml, OCaml, OCamlBytes, OCamlInt,
     OCamlInt32, OCamlList, ToRust,

--- a/tezos/api/src/ocaml_conv/from_ocaml.rs
+++ b/tezos/api/src/ocaml_conv/from_ocaml.rs
@@ -41,7 +41,9 @@ macro_rules! from_ocaml_typed_hash {
                 unsafe {
                     let vec: Vec<u8> = v.field::<OCamlBytes>(0).to_rust();
                     use std::convert::TryFrom;
-                    $rust_name::try_from(vec).unwrap()
+                    $rust_name::try_from(vec).unwrap_or_else(|e| {
+                        unreachable!(format!("Wrong bytes received from OCaml: {:?}", e))
+                    })
                 }
             }
         }
@@ -60,6 +62,7 @@ from_ocaml_typed_hash!(
     OperationMetadataListListHash
 );
 
+// TODO: TE-367: review once ocaml-interop has been upgraded
 unsafe impl FromOCaml<OCamlChainId> for ChainId {
     fn from_ocaml(v: OCaml<OCamlChainId>) -> Self {
         let v: OCaml<OCamlBytes> = unsafe { std::mem::transmute(v) };

--- a/tezos/api/src/ocaml_conv/mod.rs
+++ b/tezos/api/src/ocaml_conv/mod.rs
@@ -51,7 +51,7 @@ pub struct OCamlProtocolHash {}
 pub struct OCamlBlockMetadataHash {}
 pub struct OCamlOperationMetadataHash {}
 pub struct OCamlOperationMetadataListListHash {}
-pub struct OCamlChainId(pub OCamlBytes);
+pub struct OCamlChainId(OCamlBytes);
 
 pub mod from_ocaml;
 pub mod to_ocaml;

--- a/tezos/api/src/ocaml_conv/mod.rs
+++ b/tezos/api/src/ocaml_conv/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use crypto::hash::Hash;
+use ocaml_interop::OCamlBytes;
 use tezos_messages::p2p::encoding::{
     block_header::{Fitness, Level},
     operations_for_blocks::Path,
@@ -50,7 +51,7 @@ pub struct OCamlProtocolHash {}
 pub struct OCamlBlockMetadataHash {}
 pub struct OCamlOperationMetadataHash {}
 pub struct OCamlOperationMetadataListListHash {}
-pub struct OCamlChainId {}
+pub struct OCamlChainId(pub OCamlBytes);
 
 pub mod from_ocaml;
 pub mod to_ocaml;

--- a/tezos/api/src/ocaml_conv/mod.rs
+++ b/tezos/api/src/ocaml_conv/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 use crypto::hash::Hash;
-use ocaml_interop::OCamlBytes;
 use tezos_messages::p2p::encoding::{
     block_header::{Fitness, Level},
     operations_for_blocks::Path,
@@ -51,7 +50,7 @@ pub struct OCamlProtocolHash {}
 pub struct OCamlBlockMetadataHash {}
 pub struct OCamlOperationMetadataHash {}
 pub struct OCamlOperationMetadataListListHash {}
-pub struct OCamlChainId(OCamlBytes);
+pub struct OCamlChainId {}
 
 pub mod from_ocaml;
 pub mod to_ocaml;

--- a/tezos/api/src/ocaml_conv/mod.rs
+++ b/tezos/api/src/ocaml_conv/mod.rs
@@ -50,6 +50,7 @@ pub struct OCamlProtocolHash {}
 pub struct OCamlBlockMetadataHash {}
 pub struct OCamlOperationMetadataHash {}
 pub struct OCamlOperationMetadataListListHash {}
+pub struct OCamlChainId {}
 
 pub mod from_ocaml;
 pub mod to_ocaml;

--- a/tezos/api/src/ocaml_conv/to_ocaml.rs
+++ b/tezos/api/src/ocaml_conv/to_ocaml.rs
@@ -13,7 +13,7 @@ use crate::ffi::{
     RpcMethod, RpcRequest, ValidateOperationRequest,
 };
 use crypto::hash::{
-    BlockHash, BlockMetadataHash, ChainId, ContextHash, Hash, OperationListListHash,
+    BlockHash, BlockMetadataHash, ChainId, ContextHash, Hash, OperationHash, OperationListListHash,
     OperationMetadataHash, OperationMetadataListListHash, ProtocolHash,
 };
 use ocaml_interop::{
@@ -62,7 +62,7 @@ macro_rules! to_ocaml_hash {
 }
 
 to_ocaml_hash!(OCamlOperationListListHash, OperationListListHash);
-to_ocaml_hash!(OCamlOperationHash, Hash);
+to_ocaml_hash!(OCamlOperationHash, OperationHash);
 to_ocaml_hash!(OCamlBlockHash, BlockHash);
 to_ocaml_hash!(OCamlContextHash, ContextHash);
 to_ocaml_hash!(OCamlProtocolHash, ProtocolHash);
@@ -75,6 +75,7 @@ to_ocaml_hash!(
 
 // Other
 
+// TODO: TE-367: review once ocaml-interop has been upgraded
 unsafe impl ToOCaml<OCamlChainId> for ChainId {
     fn to_ocaml(&self, gc: OCamlAllocToken) -> OCamlAllocResult<OCamlChainId> {
         let ocaml_bytes: OCamlAllocResult<OCamlBytes> = self.0.to_ocaml(gc);
@@ -130,7 +131,7 @@ impl<'a> From<&'a Operation> for FfiOperation<'a> {
 
 impl_to_ocaml_record! {
     ApplyBlockRequest {
-        chain_id: OCamlBytes => chain_id.as_ref(),
+        chain_id: OCamlChainId,
         block_header: BlockHeader => FfiBlockHeader::from(block_header),
         pred_header: BlockHeader => FfiBlockHeader::from(pred_header),
         max_operations_ttl: OCamlInt,
@@ -164,7 +165,7 @@ impl_to_ocaml_record! {
 impl_to_ocaml_record! {
     ForkingTestchainData {
         forking_block_hash: OCamlBlockHash,
-        test_chain_id: OCamlBytes => test_chain_id.as_ref(),
+        test_chain_id: OCamlChainId,
     }
 }
 

--- a/tezos/api/src/ocaml_conv/to_ocaml.rs
+++ b/tezos/api/src/ocaml_conv/to_ocaml.rs
@@ -3,9 +3,9 @@
 
 use super::{
     FfiBlockHeader, FfiBlockHeaderShellHeader, FfiOperation, FfiOperationShellHeader,
-    OCamlBlockHash, OCamlBlockMetadataHash, OCamlContextHash, OCamlHash, OCamlOperationHash,
-    OCamlOperationListListHash, OCamlOperationMetadataHash, OCamlOperationMetadataListListHash,
-    OCamlProtocolHash, TaggedHash, OCamlChainId,
+    OCamlBlockHash, OCamlBlockMetadataHash, OCamlChainId, OCamlContextHash, OCamlHash,
+    OCamlOperationHash, OCamlOperationListListHash, OCamlOperationMetadataHash,
+    OCamlOperationMetadataListListHash, OCamlProtocolHash, TaggedHash,
 };
 use crate::ffi::{
     ApplyBlockRequest, ApplyBlockResponse, BeginApplicationRequest, BeginConstructionRequest,
@@ -13,8 +13,8 @@ use crate::ffi::{
     RpcMethod, RpcRequest, ValidateOperationRequest,
 };
 use crypto::hash::{
-    BlockHash, BlockMetadataHash, ContextHash, Hash, OperationListListHash, OperationMetadataHash,
-    OperationMetadataListListHash, ProtocolHash, ChainId,
+    BlockHash, BlockMetadataHash, ChainId, ContextHash, Hash, OperationListListHash,
+    OperationMetadataHash, OperationMetadataListListHash, ProtocolHash,
 };
 use ocaml_interop::{
     impl_to_ocaml_record, impl_to_ocaml_variant, ocaml_alloc_record, ocaml_alloc_variant,

--- a/tezos/api/src/ocaml_conv/to_ocaml.rs
+++ b/tezos/api/src/ocaml_conv/to_ocaml.rs
@@ -5,7 +5,7 @@ use super::{
     FfiBlockHeader, FfiBlockHeaderShellHeader, FfiOperation, FfiOperationShellHeader,
     OCamlBlockHash, OCamlBlockMetadataHash, OCamlContextHash, OCamlHash, OCamlOperationHash,
     OCamlOperationListListHash, OCamlOperationMetadataHash, OCamlOperationMetadataListListHash,
-    OCamlProtocolHash, TaggedHash,
+    OCamlProtocolHash, TaggedHash, OCamlChainId,
 };
 use crate::ffi::{
     ApplyBlockRequest, ApplyBlockResponse, BeginApplicationRequest, BeginConstructionRequest,
@@ -14,7 +14,7 @@ use crate::ffi::{
 };
 use crypto::hash::{
     BlockHash, BlockMetadataHash, ContextHash, Hash, OperationListListHash, OperationMetadataHash,
-    OperationMetadataListListHash, ProtocolHash,
+    OperationMetadataListListHash, ProtocolHash, ChainId,
 };
 use ocaml_interop::{
     impl_to_ocaml_record, impl_to_ocaml_variant, ocaml_alloc_record, ocaml_alloc_variant,
@@ -50,7 +50,7 @@ macro_rules! to_ocaml_hash {
     ($ocaml_name:ty, $rust_name:ty) => {
         unsafe impl ToOCaml<$ocaml_name> for $rust_name {
             fn to_ocaml(&self, _token: OCamlAllocToken) -> OCamlAllocResult<$ocaml_name> {
-                let tagged = TaggedHash::Hash(self);
+                let tagged = TaggedHash::Hash(self.as_ref());
                 ocaml_alloc_variant! {
                     tagged => {
                         TaggedHash::Hash(hash: OCamlBytes)
@@ -72,19 +72,24 @@ to_ocaml_hash!(
     OCamlOperationMetadataListListHash,
     OperationMetadataListListHash
 );
+to_ocaml_hash!(OCamlChainId, ChainId);
+
 // Other
 
 impl<'a> From<&'a BlockHeader> for FfiBlockHeaderShellHeader<'a> {
     fn from(block_header: &'a BlockHeader) -> Self {
+        let predecessor_hash: &'a Hash = block_header.predecessor().as_ref();
+        let operations_hash: &'a Hash = block_header.operations_hash().as_ref();
+        let context: &'a Hash = block_header.context().as_ref();
         Self {
             level: block_header.level(),
             proto_level: block_header.proto() as i32,
-            predecessor: block_header.predecessor().into(),
+            predecessor: predecessor_hash.into(),
             timestamp: block_header.timestamp(),
             validation_passes: block_header.validation_pass() as i32,
-            operations_hash: block_header.operations_hash().into(),
+            operations_hash: operations_hash.into(),
             fitness: block_header.fitness(),
-            context: block_header.context().into(),
+            context: context.into(),
         }
     }
 }
@@ -102,7 +107,7 @@ impl<'a> From<&'a BlockHeader> for FfiBlockHeader<'a> {
 impl<'a> From<&'a Operation> for FfiOperationShellHeader<'a> {
     fn from(operation: &'a Operation) -> Self {
         Self {
-            branch: TaggedHash::Hash(operation.branch()),
+            branch: TaggedHash::Hash(operation.branch().as_ref()),
         }
     }
 }
@@ -119,7 +124,7 @@ impl<'a> From<&'a Operation> for FfiOperation<'a> {
 
 impl_to_ocaml_record! {
     ApplyBlockRequest {
-        chain_id: OCamlBytes,
+        chain_id: OCamlBytes => chain_id.as_ref(),
         block_header: BlockHeader => FfiBlockHeader::from(block_header),
         pred_header: BlockHeader => FfiBlockHeader::from(pred_header),
         max_operations_ttl: OCamlInt,
@@ -153,13 +158,13 @@ impl_to_ocaml_record! {
 impl_to_ocaml_record! {
     ForkingTestchainData {
         forking_block_hash: OCamlBlockHash,
-        test_chain_id: OCamlBytes,
+        test_chain_id: OCamlChainId,
     }
 }
 
 impl_to_ocaml_record! {
     BeginApplicationRequest {
-        chain_id: OCamlBytes,
+        chain_id: OCamlChainId,
         pred_header: BlockHeader => FfiBlockHeader::from(pred_header),
         block_header: BlockHeader => FfiBlockHeader::from(block_header),
     }
@@ -167,7 +172,7 @@ impl_to_ocaml_record! {
 
 impl_to_ocaml_record! {
     BeginConstructionRequest {
-        chain_id: OCamlBytes,
+        chain_id: OCamlChainId,
         predecessor: BlockHeader => FfiBlockHeader::from(predecessor),
         protocol_data: Option<OCamlBytes>,
     }
@@ -175,7 +180,7 @@ impl_to_ocaml_record! {
 
 impl_to_ocaml_record! {
     PrevalidatorWrapper {
-        chain_id: OCamlBytes,
+        chain_id: OCamlChainId,
         protocol: OCamlProtocolHash,
         context_fitness: Option<OCamlList<OCamlBytes>>
     }
@@ -211,7 +216,7 @@ impl_to_ocaml_variant! {
 impl_to_ocaml_record! {
     ProtocolRpcRequest {
         block_header: BlockHeader => FfiBlockHeader::from(block_header),
-        chain_id: OCamlBytes,
+        chain_id: OCamlChainId,
         chain_arg: OCamlBytes,
         request: RpcRequest,
     }

--- a/tezos/api/src/ocaml_conv/to_ocaml.rs
+++ b/tezos/api/src/ocaml_conv/to_ocaml.rs
@@ -72,9 +72,15 @@ to_ocaml_hash!(
     OCamlOperationMetadataListListHash,
     OperationMetadataListListHash
 );
-to_ocaml_hash!(OCamlChainId, ChainId);
 
 // Other
+
+unsafe impl ToOCaml<OCamlChainId> for ChainId {
+    fn to_ocaml(&self, gc: OCamlAllocToken) -> OCamlAllocResult<OCamlChainId> {
+        let ocaml_bytes: OCamlAllocResult<OCamlBytes> = self.0.to_ocaml(gc);
+        unsafe { std::mem::transmute(ocaml_bytes) }
+    }
+}
 
 impl<'a> From<&'a BlockHeader> for FfiBlockHeaderShellHeader<'a> {
     fn from(block_header: &'a BlockHeader) -> Self {
@@ -158,7 +164,7 @@ impl_to_ocaml_record! {
 impl_to_ocaml_record! {
     ForkingTestchainData {
         forking_block_hash: OCamlBlockHash,
-        test_chain_id: OCamlChainId,
+        test_chain_id: OCamlBytes => test_chain_id.as_ref(),
     }
 }
 

--- a/tezos/client/benches/bench_apply_first_three_blocks.rs
+++ b/tezos/client/benches/bench_apply_first_three_blocks.rs
@@ -225,7 +225,10 @@ mod test_data {
                     .map(|op| Operation::from_bytes(hex::decode(op).unwrap()).unwrap())
                     .collect();
                 OperationsForBlocksMessage::new(
-                    OperationsForBlock::new(hex::decode(block_hash).unwrap().try_into().unwrap(), 4),
+                    OperationsForBlock::new(
+                        hex::decode(block_hash).unwrap().try_into().unwrap(),
+                        4,
+                    ),
                     Path::Op,
                     ops,
                 )

--- a/tezos/client/benches/bench_apply_first_three_blocks.rs
+++ b/tezos/client/benches/bench_apply_first_three_blocks.rs
@@ -165,7 +165,9 @@ fn init_test_protocol_context(dir_name: &str) -> (ChainId, BlockHeader, InitProt
 }
 
 mod test_data {
-    use crypto::hash::{ContextHash, HashType};
+    use std::convert::TryInto;
+
+    use crypto::hash::ContextHash;
     use tezos_api::environment::TezosEnvironment;
     use tezos_messages::p2p::binary_message::BinaryMessage;
     use tezos_messages::p2p::encoding::prelude::*;
@@ -173,7 +175,7 @@ mod test_data {
     pub const TEZOS_NETWORK: TezosEnvironment = TezosEnvironment::Alphanet;
 
     pub fn context_hash(hash: &str) -> ContextHash {
-        HashType::ContextHash.b58check_to_hash(hash).unwrap()
+        ContextHash::from_base58_check(hash).unwrap()
     }
 
     // BMPtRJqFGQJRTfn8bXQR2grLE1M97XnUmG5vgjHMW7St1Wub7Cd
@@ -223,7 +225,7 @@ mod test_data {
                     .map(|op| Operation::from_bytes(hex::decode(op).unwrap()).unwrap())
                     .collect();
                 OperationsForBlocksMessage::new(
-                    OperationsForBlock::new(hex::decode(block_hash).unwrap(), 4),
+                    OperationsForBlock::new(hex::decode(block_hash).unwrap().try_into().unwrap(), 4),
                     Path::Op,
                     ops,
                 )

--- a/tezos/client/src/client.rs
+++ b/tezos/client/src/client.rs
@@ -55,9 +55,9 @@ pub fn genesis_result_data(
     genesis_max_operations_ttl: u16,
 ) -> Result<CommitGenesisResult, GetDataError> {
     match ffi::genesis_result_data(
-        context_hash.clone(),
-        chain_id.clone(),
-        protocol_hash.clone(),
+        context_hash.as_ref().clone(),
+        chain_id.as_ref().clone(),
+        protocol_hash.as_ref().clone(),
         genesis_max_operations_ttl,
     ) {
         Ok(result) => Ok(result?),
@@ -179,7 +179,7 @@ pub fn decode_context_data(
     key: Vec<String>,
     data: Vec<u8>,
 ) -> Result<Option<String>, ContextDataError> {
-    match ffi::decode_context_data(protocol_hash, key, data) {
+    match ffi::decode_context_data(protocol_hash.into(), key, data) {
         Ok(result) => Ok(result?),
         Err(e) => Err(ContextDataError::DecodeError {
             message: format!("FFI 'decode_context_data' failed! Reason: {:?}", e),
@@ -192,7 +192,7 @@ pub fn assert_encoding_for_protocol_data(
     protocol_hash: ProtocolHash,
     protocol_data: Vec<u8>,
 ) -> Result<(), ProtocolDataError> {
-    match ffi::assert_encoding_for_protocol_data(protocol_hash, protocol_data) {
+    match ffi::assert_encoding_for_protocol_data(protocol_hash.into(), protocol_data) {
         Ok(result) => Ok(result?),
         Err(e) => Err(ProtocolDataError::DecodeError {
             message: format!(

--- a/tezos/client/tests/bootstrap_storage_protocol_v1_test.rs
+++ b/tezos/client/tests/bootstrap_storage_protocol_v1_test.rs
@@ -6,8 +6,7 @@
 use serial_test::serial;
 
 use crypto::hash::{
-    BlockMetadataHash, ChainId, OperationMetadataHash, OperationMetadataListListHash,
-    ProtocolHash,
+    BlockMetadataHash, ChainId, OperationMetadataHash, OperationMetadataListListHash, ProtocolHash,
 };
 use tezos_api::environment::{
     TezosEnvironment, TezosEnvironmentConfiguration, OPERATION_LIST_LIST_HASH_EMPTY, TEZOS_ENV,
@@ -803,10 +802,7 @@ fn assert_contains(value: &str, attribute: &str) {
 
 fn assert_block_metadata_hash(expected_base58_string: &str, tested: &Option<BlockMetadataHash>) {
     match tested {
-        Some(hash) => assert_eq!(
-            expected_base58_string,
-            &hash.to_base58_check()
-        ),
+        Some(hash) => assert_eq!(expected_base58_string, &hash.to_base58_check()),
         None => panic!(
             "assert_block_metadata_hash failed: expecting : `{:?}` but has None",
             expected_base58_string
@@ -819,10 +815,7 @@ fn assert_operation_metadata_hash(
     tested: &Option<OperationMetadataListListHash>,
 ) {
     match tested {
-        Some(hash) => assert_eq!(
-            expected_base58_string,
-            hash.to_base58_check()
-        ),
+        Some(hash) => assert_eq!(expected_base58_string, hash.to_base58_check()),
         None => panic!(
             "assert_operation_metadata_list_list_hash failed: expecting : `{:?}` but has None",
             expected_base58_string
@@ -936,7 +929,8 @@ mod test_data_protocol_v1 {
     pub fn block_header_level3_operation_metadata_hashes() -> Option<Vec<Vec<OperationMetadataHash>>>
     {
         Some(vec![
-            vec!["r3niv7sM81cVxAgKRy2NbYpj3JgAJfWGaqqeHZR63FqphTRpQqo".try_into()
+            vec!["r3niv7sM81cVxAgKRy2NbYpj3JgAJfWGaqqeHZR63FqphTRpQqo"
+                .try_into()
                 .expect("Failed to decode hash")],
             vec![],
             vec![],
@@ -972,11 +966,14 @@ mod test_data_protocol_v1 {
     {
         Some(vec![
             vec![
-                "r3E9xb2QxUeG56eujC66B56CV8mpwjwfdVmEpYu3FRtuEx9tyfG".try_into()
+                "r3E9xb2QxUeG56eujC66B56CV8mpwjwfdVmEpYu3FRtuEx9tyfG"
+                    .try_into()
                     .expect("Failed to decode hash"),
-                "r3fqRzBrSWQ7U7kPXppiSrCUrFJss6J96XZddYjkCemT8hohQ7R".try_into()
+                "r3fqRzBrSWQ7U7kPXppiSrCUrFJss6J96XZddYjkCemT8hohQ7R"
+                    .try_into()
                     .expect("Failed to decode hash"),
-                "r49uWMVdKFmM3icKjtfVP9yywhLLAWANW1jMxZwN5MxRA7mC4tL".try_into()
+                "r49uWMVdKFmM3icKjtfVP9yywhLLAWANW1jMxZwN5MxRA7mC4tL"
+                    .try_into()
                     .expect("Failed to decode hash"),
             ],
             vec![],
@@ -997,7 +994,10 @@ mod test_data_protocol_v1 {
                     .map(|op| Operation::from_bytes(hex::decode(op).unwrap()).unwrap())
                     .collect();
                 OperationsForBlocksMessage::new(
-                    OperationsForBlock::new(hex::decode(block_hash).unwrap().try_into().unwrap(), 4),
+                    OperationsForBlock::new(
+                        hex::decode(block_hash).unwrap().try_into().unwrap(),
+                        4,
+                    ),
                     Path::Op,
                     ops,
                 )

--- a/tezos/client/tests/bootstrap_storage_protocol_v1_test.rs
+++ b/tezos/client/tests/bootstrap_storage_protocol_v1_test.rs
@@ -6,7 +6,7 @@
 use serial_test::serial;
 
 use crypto::hash::{
-    BlockMetadataHash, ChainId, HashType, OperationMetadataHash, OperationMetadataListListHash,
+    BlockMetadataHash, ChainId, OperationMetadataHash, OperationMetadataListListHash,
     ProtocolHash,
 };
 use tezos_api::environment::{
@@ -805,7 +805,7 @@ fn assert_block_metadata_hash(expected_base58_string: &str, tested: &Option<Bloc
     match tested {
         Some(hash) => assert_eq!(
             expected_base58_string,
-            &HashType::BlockMetadataHash.hash_to_b58check(hash)
+            &hash.to_base58_check()
         ),
         None => panic!(
             "assert_block_metadata_hash failed: expecting : `{:?}` but has None",
@@ -821,7 +821,7 @@ fn assert_operation_metadata_hash(
     match tested {
         Some(hash) => assert_eq!(
             expected_base58_string,
-            &HashType::OperationMetadataListListHash.hash_to_b58check(hash)
+            hash.to_base58_check()
         ),
         None => panic!(
             "assert_operation_metadata_list_list_hash failed: expecting : `{:?}` but has None",
@@ -861,7 +861,9 @@ fn assert_operation_metadata_hashes(
 
 /// Test data for protocol_v1 like 008 edo
 mod test_data_protocol_v1 {
-    use crypto::hash::{ContextHash, HashType, OperationMetadataHash};
+    use std::convert::TryInto;
+
+    use crypto::hash::{ContextHash, OperationMetadataHash};
     use tezos_api::environment::TezosEnvironment;
     use tezos_messages::p2p::binary_message::BinaryMessage;
     use tezos_messages::p2p::encoding::prelude::*;
@@ -869,7 +871,7 @@ mod test_data_protocol_v1 {
     pub const TEZOS_NETWORK: TezosEnvironment = TezosEnvironment::Edonet;
 
     pub fn context_hash(hash: &str) -> ContextHash {
-        HashType::ContextHash.b58check_to_hash(hash).unwrap()
+        ContextHash::from_base58_check(hash).unwrap()
     }
 
     // BLUzCt33hGwAsT4UdPXgqH2MjEZErpPfo5nL4rtQR5dStpixNrA
@@ -934,8 +936,7 @@ mod test_data_protocol_v1 {
     pub fn block_header_level3_operation_metadata_hashes() -> Option<Vec<Vec<OperationMetadataHash>>>
     {
         Some(vec![
-            vec![HashType::OperationMetadataHash
-                .b58check_to_hash("r3niv7sM81cVxAgKRy2NbYpj3JgAJfWGaqqeHZR63FqphTRpQqo")
+            vec!["r3niv7sM81cVxAgKRy2NbYpj3JgAJfWGaqqeHZR63FqphTRpQqo".try_into()
                 .expect("Failed to decode hash")],
             vec![],
             vec![],
@@ -971,14 +972,11 @@ mod test_data_protocol_v1 {
     {
         Some(vec![
             vec![
-                HashType::OperationMetadataHash
-                    .b58check_to_hash("r3E9xb2QxUeG56eujC66B56CV8mpwjwfdVmEpYu3FRtuEx9tyfG")
+                "r3E9xb2QxUeG56eujC66B56CV8mpwjwfdVmEpYu3FRtuEx9tyfG".try_into()
                     .expect("Failed to decode hash"),
-                HashType::OperationMetadataHash
-                    .b58check_to_hash("r3fqRzBrSWQ7U7kPXppiSrCUrFJss6J96XZddYjkCemT8hohQ7R")
+                "r3fqRzBrSWQ7U7kPXppiSrCUrFJss6J96XZddYjkCemT8hohQ7R".try_into()
                     .expect("Failed to decode hash"),
-                HashType::OperationMetadataHash
-                    .b58check_to_hash("r49uWMVdKFmM3icKjtfVP9yywhLLAWANW1jMxZwN5MxRA7mC4tL")
+                "r49uWMVdKFmM3icKjtfVP9yywhLLAWANW1jMxZwN5MxRA7mC4tL".try_into()
                     .expect("Failed to decode hash"),
             ],
             vec![],
@@ -999,7 +997,7 @@ mod test_data_protocol_v1 {
                     .map(|op| Operation::from_bytes(hex::decode(op).unwrap()).unwrap())
                     .collect();
                 OperationsForBlocksMessage::new(
-                    OperationsForBlock::new(hex::decode(block_hash).unwrap(), 4),
+                    OperationsForBlock::new(hex::decode(block_hash).unwrap().try_into().unwrap(), 4),
                     Path::Op,
                     ops,
                 )

--- a/tezos/client/tests/bootstrap_storage_test.rs
+++ b/tezos/client/tests/bootstrap_storage_test.rs
@@ -634,7 +634,9 @@ fn assert_contains(value: &str, attribute: &str) {
 }
 
 mod test_data {
-    use crypto::hash::{ContextHash, HashType};
+    use std::convert::TryFrom;
+
+    use crypto::hash::{BlockHash, ContextHash};
     use tezos_api::environment::TezosEnvironment;
     use tezos_messages::p2p::binary_message::BinaryMessage;
     use tezos_messages::p2p::encoding::prelude::*;
@@ -642,7 +644,7 @@ mod test_data {
     pub const TEZOS_NETWORK: TezosEnvironment = TezosEnvironment::Alphanet;
 
     pub fn context_hash(hash: &str) -> ContextHash {
-        HashType::ContextHash.b58check_to_hash(hash).unwrap()
+        ContextHash::from_base58_check(hash).unwrap()
     }
 
     // BMPtRJqFGQJRTfn8bXQR2grLE1M97XnUmG5vgjHMW7St1Wub7Cd
@@ -691,7 +693,7 @@ mod test_data {
                     .map(|op| Operation::from_bytes(hex::decode(op).unwrap()).unwrap())
                     .collect();
                 OperationsForBlocksMessage::new(
-                    OperationsForBlock::new(hex::decode(block_hash).unwrap(), 4),
+                    OperationsForBlock::new(BlockHash::try_from(hex::decode(block_hash).unwrap()).unwrap(), 4),
                     Path::Op,
                     ops,
                 )

--- a/tezos/client/tests/bootstrap_storage_test.rs
+++ b/tezos/client/tests/bootstrap_storage_test.rs
@@ -693,7 +693,10 @@ mod test_data {
                     .map(|op| Operation::from_bytes(hex::decode(op).unwrap()).unwrap())
                     .collect();
                 OperationsForBlocksMessage::new(
-                    OperationsForBlock::new(BlockHash::try_from(hex::decode(block_hash).unwrap()).unwrap(), 4),
+                    OperationsForBlock::new(
+                        BlockHash::try_from(hex::decode(block_hash).unwrap()).unwrap(),
+                        4,
+                    ),
                     Path::Op,
                     ops,
                 )

--- a/tezos/client/tests/decode_context_data_test.rs
+++ b/tezos/client/tests/decode_context_data_test.rs
@@ -5,12 +5,12 @@ use std::env;
 
 use serial_test::serial;
 
-use crypto::hash::{HashType, ProtocolHash};
+use crypto::hash::ProtocolHash;
 use tezos_api::ffi::TezosRuntimeConfiguration;
 use tezos_client::client;
 
 fn protocol(hash: &str) -> ProtocolHash {
-    HashType::ProtocolHash.b58check_to_hash(hash).unwrap()
+    ProtocolHash::from_base58_check(hash).unwrap()
 }
 
 fn data(data_as_hex: &str) -> Vec<u8> {

--- a/tezos/client/tests/ffi_rpc_router_test.rs
+++ b/tezos/client/tests/ffi_rpc_router_test.rs
@@ -623,7 +623,10 @@ mod test_data {
                     .map(|op| Operation::from_bytes(hex::decode(op).unwrap()).unwrap())
                     .collect();
                 OperationsForBlocksMessage::new(
-                    OperationsForBlock::new(hex::decode(block_hash).unwrap().try_into().unwrap(), 4),
+                    OperationsForBlock::new(
+                        hex::decode(block_hash).unwrap().try_into().unwrap(),
+                        4,
+                    ),
                     Path::Op,
                     ops,
                 )

--- a/tezos/client/tests/ffi_rpc_router_test.rs
+++ b/tezos/client/tests/ffi_rpc_router_test.rs
@@ -361,7 +361,7 @@ fn test_compute_path() -> Result<(), failure::Error> {
             .map(|validation_pass| {
                 validation_pass
                     .iter()
-                    .map(|op| op.message_hash().unwrap())
+                    .map(|op| op.message_typed_hash().unwrap())
                     .collect()
             })
             .collect(),
@@ -448,7 +448,9 @@ fn apply_blocks_1(chain_id: &ChainId, genesis_block_header: BlockHeader) -> Bloc
 }
 
 mod test_data {
-    use crypto::hash::{ContextHash, HashType};
+    use std::convert::TryInto;
+
+    use crypto::hash::ContextHash;
     use tezos_api::environment::TezosEnvironment;
     use tezos_api::ffi::PatchContext;
     use tezos_messages::p2p::binary_message::BinaryMessage;
@@ -457,7 +459,7 @@ mod test_data {
     pub const TEZOS_NETWORK: TezosEnvironment = TezosEnvironment::Sandbox;
 
     pub fn context_hash(hash: &str) -> ContextHash {
-        HashType::ContextHash.b58check_to_hash(hash).unwrap()
+        ContextHash::from_base58_check(hash).unwrap()
     }
 
     // BMPtRJqFGQJRTfn8bXQR2grLE1M97XnUmG5vgjHMW7St1Wub7Cd
@@ -621,7 +623,7 @@ mod test_data {
                     .map(|op| Operation::from_bytes(hex::decode(op).unwrap()).unwrap())
                     .collect();
                 OperationsForBlocksMessage::new(
-                    OperationsForBlock::new(hex::decode(block_hash).unwrap(), 4),
+                    OperationsForBlock::new(hex::decode(block_hash).unwrap().try_into().unwrap(), 4),
                     Path::Op,
                     ops,
                 )

--- a/tezos/client/tests/ffi_tests.rs
+++ b/tezos/client/tests/ffi_tests.rs
@@ -1,6 +1,8 @@
+use std::convert::TryFrom;
+
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
-use crypto::hash::HashType;
+use crypto::hash::ProtocolHash;
 use serial_test::serial;
 use tezos_api::environment::{self, TezosEnvironment};
 use tezos_api::ffi::{InitProtocolContextResult, TezosRuntimeConfiguration};
@@ -23,7 +25,6 @@ fn test_init_protocol_context() {
     .unwrap()
     .unwrap();
 
-    let context_hash_encoding = HashType::ContextHash;
     let storage_dir = "test_storage_01";
     let tezos_env = TezosEnvironment::Carthagenet;
 
@@ -38,9 +39,7 @@ fn test_init_protocol_context() {
     assert!(genesis_commit_hash.is_some());
     let genesis_commit_hash = genesis_commit_hash.unwrap();
     assert_eq!(
-        context_hash_encoding
-            .hash_to_b58check(&genesis_commit_hash)
-            .as_str(),
+        genesis_commit_hash.to_base58_check(),
         "CoWZVRSM6DdNUpn3mamy7e8rUSxQVWkQCQfJBg7DrTVXUjzGZGCa",
     );
 
@@ -68,11 +67,9 @@ fn test_assert_encoding_for_protocol_data() {
         hex::decode("0000000201dd9fb5edc4f29e7d28f41fe56d57ad172b7686ed140ad50294488b68de29474d000000005c017cd804683625c2445a4e9564bf710c5528fd99a7d150d2a2a323bc22ff9e2710da4f6d0000001100000001000000000800000000000000029bd8c75dec93c276d2d8e8febc3aa6c9471cb2cb42236b3ab4ca5f1f2a0892f6000500000003ba671eef00d6a8bea20a4677fae51268ab6be7bd8cfc373cd6ac9e0a00064efcc404e1fb39409c5df255f7651e3d1bb5d91cb2172b687e5d56ebde58cfd92e1855aaafbf05").unwrap(),
     ).expect("Failed to decode block header 2");
 
-    let protocol_hash_1 = HashType::ProtocolHash
-        .b58check_to_hash("PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex")
+    let protocol_hash_1 = ProtocolHash::try_from("PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex")
         .expect("Failed to decode protocol hash");
-    let protocol_hash_2 = HashType::ProtocolHash
-        .b58check_to_hash("PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS")
+    let protocol_hash_2 = ProtocolHash::try_from("PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS")
         .expect("Failed to decode protocol hash");
 
     // check

--- a/tezos/client/tests/ffi_tests.rs
+++ b/tezos/client/tests/ffi_tests.rs
@@ -67,10 +67,12 @@ fn test_assert_encoding_for_protocol_data() {
         hex::decode("0000000201dd9fb5edc4f29e7d28f41fe56d57ad172b7686ed140ad50294488b68de29474d000000005c017cd804683625c2445a4e9564bf710c5528fd99a7d150d2a2a323bc22ff9e2710da4f6d0000001100000001000000000800000000000000029bd8c75dec93c276d2d8e8febc3aa6c9471cb2cb42236b3ab4ca5f1f2a0892f6000500000003ba671eef00d6a8bea20a4677fae51268ab6be7bd8cfc373cd6ac9e0a00064efcc404e1fb39409c5df255f7651e3d1bb5d91cb2172b687e5d56ebde58cfd92e1855aaafbf05").unwrap(),
     ).expect("Failed to decode block header 2");
 
-    let protocol_hash_1 = ProtocolHash::try_from("PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex")
-        .expect("Failed to decode protocol hash");
-    let protocol_hash_2 = ProtocolHash::try_from("PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS")
-        .expect("Failed to decode protocol hash");
+    let protocol_hash_1 =
+        ProtocolHash::try_from("PtYuensgYBb3G3x1hLLbCmcav8ue8Kyd2khADcL5LsT5R1hcXex")
+            .expect("Failed to decode protocol hash");
+    let protocol_hash_2 =
+        ProtocolHash::try_from("PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS")
+            .expect("Failed to decode protocol hash");
 
     // check
     assert!(client::assert_encoding_for_protocol_data(

--- a/tezos/client/tests/init_storage_tests.rs
+++ b/tezos/client/tests/init_storage_tests.rs
@@ -1,11 +1,11 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::collections::HashSet;
+use std::{collections::HashSet, convert::TryFrom};
 
 use enum_iterator::IntoEnumIterator;
 
-use crypto::hash::{ContextHash, HashType, ProtocolHash};
+use crypto::hash::{ContextHash, ProtocolHash};
 use tezos_api::environment::{TezosEnvironment, TezosEnvironmentConfiguration, TEZOS_ENV};
 use tezos_api::ffi::{PatchContext, TezosRuntimeConfiguration};
 use tezos_client::client;
@@ -115,8 +115,7 @@ fn test_init_empty_context_for_sandbox_with_patch_json() -> Result<(), failure::
             if let Some(commit_hash) = &init_info.genesis_commit_hash {
                 assert_eq!(
                     *commit_hash,
-                    HashType::ContextHash
-                        .b58check_to_hash("CoVBYdAGWBoDTkiVXJEGX6FQvDN1oGCPJu8STMvaTYdeh7N3KGTz")?
+                    ContextHash::try_from("CoVBYdAGWBoDTkiVXJEGX6FQvDN1oGCPJu8STMvaTYdeh7N3KGTz")?
                 )
             } else {
                 panic!("Expected some context hash")
@@ -163,8 +162,7 @@ fn test_init_empty_context_for_sandbox_without_patch_json() -> Result<(), failur
             if let Some(commit_hash) = &init_info.genesis_commit_hash {
                 assert_eq!(
                     *commit_hash,
-                    HashType::ContextHash
-                        .b58check_to_hash("CoVewPVcrKctWXSbrRgoGD6NmkdbDhmTFk5oi1FZpEcRT3bmKxdQ")?
+                    ContextHash::try_from("CoVewPVcrKctWXSbrRgoGD6NmkdbDhmTFk5oi1FZpEcRT3bmKxdQ")?
                 )
             } else {
                 panic!("Expected some context hash")

--- a/tezos/client/tests/prevalidator_mempool_protocol_v1_test.rs
+++ b/tezos/client/tests/prevalidator_mempool_protocol_v1_test.rs
@@ -177,7 +177,9 @@ fn apply_blocks_1_2(chain_id: &ChainId, genesis_block_header: BlockHeader) -> Bl
 
 /// Test data for protocol_v1 like 008 edo
 mod test_data_protocol_v1 {
-    use crypto::hash::{ContextHash, HashType};
+    use std::convert::TryFrom;
+
+    use crypto::hash::{BlockHash, ContextHash};
     use tezos_api::environment::TezosEnvironment;
     use tezos_messages::p2p::binary_message::BinaryMessage;
     use tezos_messages::p2p::encoding::prelude::*;
@@ -185,7 +187,7 @@ mod test_data_protocol_v1 {
     pub const TEZOS_NETWORK: TezosEnvironment = TezosEnvironment::Edonet;
 
     pub fn context_hash(hash: &str) -> ContextHash {
-        HashType::ContextHash.b58check_to_hash(hash).unwrap()
+        ContextHash::from_base58_check(hash).unwrap()
     }
 
     // BLUzCt33hGwAsT4UdPXgqH2MjEZErpPfo5nL4rtQR5dStpixNrA
@@ -228,7 +230,7 @@ mod test_data_protocol_v1 {
                     .map(|op| Operation::from_bytes(hex::decode(op).unwrap()).unwrap())
                     .collect();
                 OperationsForBlocksMessage::new(
-                    OperationsForBlock::new(hex::decode(block_hash).unwrap(), 4),
+                    OperationsForBlock::new(BlockHash::try_from(hex::decode(block_hash).unwrap()).unwrap(), 4),
                     Path::Op,
                     ops,
                 )

--- a/tezos/client/tests/prevalidator_mempool_protocol_v1_test.rs
+++ b/tezos/client/tests/prevalidator_mempool_protocol_v1_test.rs
@@ -230,7 +230,10 @@ mod test_data_protocol_v1 {
                     .map(|op| Operation::from_bytes(hex::decode(op).unwrap()).unwrap())
                     .collect();
                 OperationsForBlocksMessage::new(
-                    OperationsForBlock::new(BlockHash::try_from(hex::decode(block_hash).unwrap()).unwrap(), 4),
+                    OperationsForBlock::new(
+                        BlockHash::try_from(hex::decode(block_hash).unwrap()).unwrap(),
+                        4,
+                    ),
                     Path::Op,
                     ops,
                 )

--- a/tezos/client/tests/prevalidator_mempool_test.rs
+++ b/tezos/client/tests/prevalidator_mempool_test.rs
@@ -157,7 +157,9 @@ fn apply_blocks_1_2(chain_id: &ChainId, genesis_block_header: BlockHeader) -> Bl
 }
 
 mod test_data {
-    use crypto::hash::{ContextHash, HashType};
+    use std::convert::TryInto;
+
+    use crypto::hash::ContextHash;
     use tezos_api::environment::TezosEnvironment;
     use tezos_messages::p2p::binary_message::BinaryMessage;
     use tezos_messages::p2p::encoding::prelude::*;
@@ -165,7 +167,7 @@ mod test_data {
     pub const TEZOS_NETWORK: TezosEnvironment = TezosEnvironment::Alphanet;
 
     pub fn context_hash(hash: &str) -> ContextHash {
-        HashType::ContextHash.b58check_to_hash(hash).unwrap()
+        ContextHash::from_base58_check(hash).unwrap()
     }
 
     // BMPtRJqFGQJRTfn8bXQR2grLE1M97XnUmG5vgjHMW7St1Wub7Cd
@@ -207,7 +209,7 @@ mod test_data {
                     .map(|op| Operation::from_bytes(hex::decode(op).unwrap()).unwrap())
                     .collect();
                 OperationsForBlocksMessage::new(
-                    OperationsForBlock::new(hex::decode(block_hash).unwrap(), 4),
+                    OperationsForBlock::new(hex::decode(block_hash).unwrap().try_into().unwrap(), 4),
                     Path::Op,
                     ops,
                 )

--- a/tezos/client/tests/prevalidator_mempool_test.rs
+++ b/tezos/client/tests/prevalidator_mempool_test.rs
@@ -209,7 +209,10 @@ mod test_data {
                     .map(|op| Operation::from_bytes(hex::decode(op).unwrap()).unwrap())
                     .collect();
                 OperationsForBlocksMessage::new(
-                    OperationsForBlock::new(hex::decode(block_hash).unwrap().try_into().unwrap(), 4),
+                    OperationsForBlock::new(
+                        hex::decode(block_hash).unwrap().try_into().unwrap(),
+                        4,
+                    ),
                     Path::Op,
                     ops,
                 )

--- a/tezos/encoding/src/json_writer.rs
+++ b/tezos/encoding/src/json_writer.rs
@@ -240,7 +240,7 @@ impl JsonWriter {
                                 _ => return Err(Error::custom(format!("Encoding::Hash could be applied only to &[u8] value but found: {:?}", value)))
                             }
                     }
-                    Ok(self.push_str(&hash_encoding.hash_to_b58check(&bytes)))
+                    Ok(self.push_str(&hash_encoding.hash_to_b58check(&bytes).map_err(|e| Error::custom(format!("Failed to encode hash: {:?}", e)))?))
                 }
                 _ => Err(Error::encoding_mismatch(encoding, value)),
             },

--- a/tezos/encoding/src/json_writer.rs
+++ b/tezos/encoding/src/json_writer.rs
@@ -240,7 +240,11 @@ impl JsonWriter {
                                 _ => return Err(Error::custom(format!("Encoding::Hash could be applied only to &[u8] value but found: {:?}", value)))
                             }
                     }
-                    Ok(self.push_str(&hash_encoding.hash_to_b58check(&bytes).map_err(|e| Error::custom(format!("Failed to encode hash: {:?}", e)))?))
+                    Ok(self.push_str(
+                        &hash_encoding.hash_to_b58check(&bytes).map_err(|e| {
+                            Error::custom(format!("Failed to encode hash: {:?}", e))
+                        })?,
+                    ))
                 }
                 _ => Err(Error::encoding_mismatch(encoding, value)),
             },

--- a/tezos/identity/src/lib.rs
+++ b/tezos/identity/src/lib.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 #![forbid(unsafe_code)]
 
-use std::{collections::HashMap, convert::TryFrom};
 use std::path::{Path, PathBuf};
+use std::{collections::HashMap, convert::TryFrom};
 use std::{fs, io};
 
 use failure::Fail;
@@ -81,10 +81,11 @@ impl Identity {
             .ok_or(IdentityError::IdentityFieldError {
                 reason: "Missing valid 'peer_id'".to_string(),
             })?;
-        let peer_id = CryptoboxPublicKeyHash::try_from(peer_id_str)
-            .map_err(|e| IdentityError::IdentityFieldError {
+        let peer_id = CryptoboxPublicKeyHash::try_from(peer_id_str).map_err(|e| {
+            IdentityError::IdentityFieldError {
                 reason: format!("Missing valid 'peer_id': {}", e),
-            })?;
+            }
+        })?;
 
         let public_key_str = identity
             .get("public_key")
@@ -139,10 +140,7 @@ impl Identity {
 
     pub fn as_json(&self) -> Result<String, IdentityError> {
         let mut identity: HashMap<&'static str, String> = Default::default();
-        identity.insert(
-            "peer_id",
-            self.peer_id.to_base58_check(),
-        );
+        identity.insert("peer_id", self.peer_id.to_base58_check());
         identity.insert("public_key", hex::encode(self.public_key.as_ref()));
         identity.insert("secret_key", hex::encode(self.secret_key.as_ref()));
         identity.insert(

--- a/tezos/identity/src/lib.rs
+++ b/tezos/identity/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 #![forbid(unsafe_code)]
 
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::TryFrom};
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
@@ -13,7 +13,6 @@ use serde_json::Value;
 use crypto::hash::CryptoboxPublicKeyHash;
 use crypto::{
     crypto_box::{random_keypair, PublicKey, SecretKey},
-    hash::HashType,
     proof_of_work::ProofOfWork,
 };
 
@@ -82,8 +81,7 @@ impl Identity {
             .ok_or(IdentityError::IdentityFieldError {
                 reason: "Missing valid 'peer_id'".to_string(),
             })?;
-        let peer_id = HashType::CryptoboxPublicKeyHash
-            .b58check_to_hash(peer_id_str)
+        let peer_id = CryptoboxPublicKeyHash::try_from(peer_id_str)
             .map_err(|e| IdentityError::IdentityFieldError {
                 reason: format!("Missing valid 'peer_id': {}", e),
             })?;
@@ -143,7 +141,7 @@ impl Identity {
         let mut identity: HashMap<&'static str, String> = Default::default();
         identity.insert(
             "peer_id",
-            HashType::CryptoboxPublicKeyHash.hash_to_b58check(&self.peer_id),
+            self.peer_id.to_base58_check(),
         );
         identity.insert("public_key", hex::encode(self.public_key.as_ref()));
         identity.insert("secret_key", hex::encode(self.secret_key.as_ref()));
@@ -186,7 +184,6 @@ mod tests {
         let identity = Identity::generate(16f64);
 
         // check
-        assert!(!identity.peer_id.is_empty());
         assert!(identity.check_peer_id().is_ok());
 
         // convert json and back

--- a/tezos/interop/Cargo.toml
+++ b/tezos/interop/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1.0"
 tezos_api = { path = "../api" }
 tezos_interop_callback = { path = "../interop_callback" }
 tezos_messages = { path = "../messages" }
+crypto = { path = "../../crypto" }
 
 [build-dependencies]
 colored = "2.0"

--- a/tezos/interop/benches/interop_benchmark.rs
+++ b/tezos/interop/benches/interop_benchmark.rs
@@ -94,7 +94,8 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let response_with_some_forking_data: ApplyBlockResponse = ApplyBlockResponse {
         validation_result_message: "validation_result_message".to_string(),
-        context_hash: "CoV16kW8WgL51SpcftQKdeqc94D6ekghMgPMmEn7TSZzFA697PeE".try_into()
+        context_hash: "CoV16kW8WgL51SpcftQKdeqc94D6ekghMgPMmEn7TSZzFA697PeE"
+            .try_into()
             .expect("failed to convert"),
         block_header_proto_json: "block_header_proto_json".to_string(),
         block_header_proto_metadata_json: "block_header_proto_metadata_json".to_string(),
@@ -103,9 +104,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         last_allowed_fork_level: 8,
         forking_testchain: true,
         forking_testchain_data: Some(ForkingTestchainData {
-            test_chain_id: "NetXgtSLGNJvNye".try_into()
-                .unwrap(),
-            forking_block_hash: "BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET".try_into()
+            test_chain_id: "NetXgtSLGNJvNye".try_into().unwrap(),
+            forking_block_hash: "BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET"
+                .try_into()
                 .unwrap(),
         }),
         block_metadata_hash: None,

--- a/tezos/interop/benches/interop_benchmark.rs
+++ b/tezos/interop/benches/interop_benchmark.rs
@@ -1,6 +1,8 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use std::convert::TryInto;
+
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use tezos_api::ffi::{
@@ -8,7 +10,6 @@ use tezos_api::ffi::{
     RustBytes, TezosRuntimeConfiguration,
 };
 
-use crypto::hash::HashType;
 use ocaml_interop::{ocaml_call, ocaml_frame, to_ocaml, ToOCaml, ToRust};
 use tezos_interop::ffi;
 use tezos_interop::runtime;
@@ -57,7 +58,7 @@ fn block_operations_from_hex(
                 .map(|op| Operation::from_bytes(op).unwrap())
                 .collect();
             OperationsForBlocksMessage::new(
-                OperationsForBlock::new(hex::decode(block_hash).unwrap(), 4),
+                OperationsForBlock::new(hex::decode(block_hash).unwrap().try_into().unwrap(), 4),
                 Path::Op,
                 ops,
             )
@@ -93,8 +94,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let response_with_some_forking_data: ApplyBlockResponse = ApplyBlockResponse {
         validation_result_message: "validation_result_message".to_string(),
-        context_hash: HashType::ContextHash
-            .b58check_to_hash("CoV16kW8WgL51SpcftQKdeqc94D6ekghMgPMmEn7TSZzFA697PeE")
+        context_hash: "CoV16kW8WgL51SpcftQKdeqc94D6ekghMgPMmEn7TSZzFA697PeE".try_into()
             .expect("failed to convert"),
         block_header_proto_json: "block_header_proto_json".to_string(),
         block_header_proto_metadata_json: "block_header_proto_metadata_json".to_string(),
@@ -103,11 +103,9 @@ fn criterion_benchmark(c: &mut Criterion) {
         last_allowed_fork_level: 8,
         forking_testchain: true,
         forking_testchain_data: Some(ForkingTestchainData {
-            test_chain_id: HashType::ChainId
-                .b58check_to_hash("NetXgtSLGNJvNye")
+            test_chain_id: "NetXgtSLGNJvNye".try_into()
                 .unwrap(),
-            forking_block_hash: HashType::BlockHash
-                .b58check_to_hash("BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET")
+            forking_block_hash: "BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET".try_into()
                 .unwrap(),
         }),
         block_metadata_hash: None,
@@ -128,7 +126,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     c.bench_function("apply_block_request_decoded_roundtrip", |b| {
         let request: ApplyBlockRequest = ApplyBlockRequestBuilder::default()
-            .chain_id(hex::decode(CHAIN_ID).unwrap())
+            .chain_id(hex::decode(CHAIN_ID).unwrap().try_into().unwrap())
             .block_header(BlockHeader::from_bytes(hex::decode(HEADER).unwrap()).unwrap())
             .pred_header(BlockHeader::from_bytes(hex::decode(HEADER).unwrap()).unwrap())
             .max_operations_ttl(MAX_OPERATIONS_TTL)

--- a/tezos/interop/src/ffi.rs
+++ b/tezos/interop/src/ffi.rs
@@ -319,14 +319,7 @@ pub fn compute_path(
 ) -> Result<Result<ComputePathResponse, CallError>, OcamlError> {
     runtime::execute(move || {
         ocaml_frame!(gc, {
-            let ocaml_request = to_ocaml!(
-                gc,
-                request
-                    .operations
-                    .iter()
-                    .map(|hs| hs.iter().map(|h| h.as_ref().to_vec()).collect::<Vec<_>>())
-                    .collect::<Vec<_>>()
-            );
+            let ocaml_request = to_ocaml!(gc, request.operations);
             let result = ocaml_call!(tezos_ffi::compute_path(gc, ocaml_request));
             match result {
                 Ok(response) => {

--- a/tezos/interop/src/ffi.rs
+++ b/tezos/interop/src/ffi.rs
@@ -1,8 +1,11 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use std::{convert::TryFrom, sync::atomic::{AtomicBool, Ordering}};
 use std::sync::Once;
+use std::{
+    convert::TryFrom,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use crypto::hash::{ContextHash, ProtocolHash};
 use ocaml_interop::{
@@ -175,8 +178,13 @@ pub fn init_protocol_context(
                             Vec<RustBytes>,
                             Option<RustBytes>,
                         ) = result.to_rust();
-                        let supported_protocol_hashes = supported_protocol_hashes.into_iter().map(|h| ProtocolHash::try_from(h)).collect::<Result<_, _>>()?;
-                        let genesis_commit_hash = genesis_commit_hash.map(|bytes| ContextHash::try_from(bytes.to_vec())).map_or(Ok(None), |r| r.map(Some))?;
+                        let supported_protocol_hashes = supported_protocol_hashes
+                            .into_iter()
+                            .map(|h| ProtocolHash::try_from(h))
+                            .collect::<Result<_, _>>()?;
+                        let genesis_commit_hash = genesis_commit_hash
+                            .map(|bytes| ContextHash::try_from(bytes.to_vec()))
+                            .map_or(Ok(None), |r| r.map(Some))?;
                         Ok(InitProtocolContextResult {
                             supported_protocol_hashes,
                             genesis_commit_hash,
@@ -311,7 +319,14 @@ pub fn compute_path(
 ) -> Result<Result<ComputePathResponse, CallError>, OcamlError> {
     runtime::execute(move || {
         ocaml_frame!(gc, {
-            let ocaml_request = to_ocaml!(gc, request.operations.iter().map(|hs| hs.iter().map(|h| h.as_ref().to_vec()).collect::<Vec<_>>()).collect::<Vec<_>>());
+            let ocaml_request = to_ocaml!(
+                gc,
+                request
+                    .operations
+                    .iter()
+                    .map(|hs| hs.iter().map(|h| h.as_ref().to_vec()).collect::<Vec<_>>())
+                    .collect::<Vec<_>>()
+            );
             let result = ocaml_call!(tezos_ffi::compute_path(gc, ocaml_request));
             match result {
                 Ok(response) => {

--- a/tezos/interop/tests/test_rust_ocaml_conv.rs
+++ b/tezos/interop/tests/test_rust_ocaml_conv.rs
@@ -39,7 +39,20 @@ const MAX_OPERATIONS_TTL: i32 = 5;
 mod tezos_ffi {
     use ocaml_interop::{ocaml, OCamlBytes, OCamlInt, OCamlInt32, OCamlInt64, OCamlList};
 
-    use tezos_api::{ffi::ApplyBlockRequest, ffi::BeginConstructionRequest, ffi::PrevalidatorWrapper, ffi::ProtocolRpcRequest, ffi::RpcMethod, ffi::RpcRequest, ffi::ValidateOperationRequest, ocaml_conv::OCamlBlockHash, ocaml_conv::OCamlContextHash, ocaml_conv::OCamlOperationHash, ocaml_conv::OCamlOperationListListHash, ocaml_conv::{OCamlChainId, OCamlProtocolHash}};
+    use tezos_api::{
+        ffi::ApplyBlockRequest,
+        ffi::BeginConstructionRequest,
+        ffi::PrevalidatorWrapper,
+        ffi::ProtocolRpcRequest,
+        ffi::RpcMethod,
+        ffi::RpcRequest,
+        ffi::ValidateOperationRequest,
+        ocaml_conv::OCamlBlockHash,
+        ocaml_conv::OCamlContextHash,
+        ocaml_conv::OCamlOperationHash,
+        ocaml_conv::OCamlOperationListListHash,
+        ocaml_conv::{OCamlChainId, OCamlProtocolHash},
+    };
     use tezos_messages::p2p::encoding::prelude::{BlockHeader, Operation};
 
     ocaml! {
@@ -118,7 +131,10 @@ fn block_operations_from_hex(
                 .map(|op| Operation::from_bytes(op).unwrap())
                 .collect();
             OperationsForBlocksMessage::new(
-                OperationsForBlock::new(BlockHash::try_from(hex::decode(block_hash).unwrap()).unwrap(), 4),
+                OperationsForBlock::new(
+                    BlockHash::try_from(hex::decode(block_hash).unwrap()).unwrap(),
+                    4,
+                ),
                 Path::Op,
                 ops,
             )
@@ -319,7 +335,7 @@ fn test_begin_construction_request_conv() {
 #[serial]
 fn test_validate_operation_request_conv() {
     let prevalidator = PrevalidatorWrapper {
-        chain_id: ChainId::try_from( hex::decode(CHAIN_ID).unwrap()).unwrap(),
+        chain_id: ChainId::try_from(hex::decode(CHAIN_ID).unwrap()).unwrap(),
         protocol: ProtocolHash::try_from(vec![1, 2, 3, 4, 5, 6, 7, 8, 9]).unwrap(),
         context_fitness: Some(vec![vec![0, 1], vec![0, 0, 1, 2, 3, 4, 5]]),
     };

--- a/tezos/interop/tests/test_rust_ocaml_conv.rs
+++ b/tezos/interop/tests/test_rust_ocaml_conv.rs
@@ -5,7 +5,7 @@ extern crate test;
 
 use std::convert::{TryFrom, TryInto};
 
-use crypto::hash::{BlockHash, ChainId, HashType, ProtocolHash};
+use crypto::hash::{BlockHash, ChainId, HashType, OperationHash, ProtocolHash};
 use ocaml_interop::{ocaml_call, ocaml_frame, to_ocaml, OCaml, ToOCaml, ToRust};
 use serial_test::serial;
 
@@ -155,12 +155,12 @@ fn sample_operations_for_request_decoded() -> Vec<Vec<RustBytes>> {
 #[test]
 #[serial]
 fn test_hash_conv() {
-    let operation_hash = hex::decode(OPERATION_HASH).unwrap();
+    let operation_hash = OperationHash::try_from(hex::decode(OPERATION_HASH).unwrap()).unwrap();
 
     let result: bool = runtime::execute(move || {
         ocaml_frame!(gc(hash_root), {
             let hash = to_ocaml!(gc, operation_hash, hash_root);
-            let hash_bytes = to_ocaml!(gc, operation_hash);
+            let hash_bytes = to_ocaml!(gc, operation_hash.as_ref());
             ocaml_call!(tezos_ffi::construct_and_compare_hash(
                 gc,
                 gc.get(&hash),

--- a/tezos/messages/src/base/mod.rs
+++ b/tezos/messages/src/base/mod.rs
@@ -5,6 +5,7 @@ use failure::Fail;
 use hex::FromHexError;
 
 use crypto::base58::FromBase58CheckError;
+use crypto::hash::FromBytesError;
 
 pub mod rpc_support;
 pub mod signature_public_key;
@@ -32,6 +33,14 @@ impl From<hex::FromHexError> for ConversionError {
 
 impl From<FromBase58CheckError> for ConversionError {
     fn from(error: FromBase58CheckError) -> Self {
+        ConversionError::InvalidHash {
+            hash: error.to_string(),
+        }
+    }
+}
+
+impl From<FromBytesError> for ConversionError {
+    fn from(error: FromBytesError) -> Self {
         ConversionError::InvalidHash {
             hash: error.to_string(),
         }

--- a/tezos/messages/src/lib.rs
+++ b/tezos/messages/src/lib.rs
@@ -8,7 +8,7 @@ use chrono::prelude::*;
 use getset::Getters;
 use serde::{Deserialize, Serialize};
 
-use crypto::hash::{BlockHash, HashType};
+use crypto::hash::BlockHash;
 
 use crate::p2p::encoding::block_header::{display_fitness, Fitness, Level};
 
@@ -49,7 +49,7 @@ impl Head {
 
     pub fn to_debug_info(&self) -> (String, Level, String) {
         (
-            HashType::BlockHash.hash_to_b58check(&self.block_hash),
+            self.block_hash.to_base58_check(),
             self.level,
             display_fitness(&self.fitness),
         )

--- a/tezos/messages/src/p2p/binary_message.rs
+++ b/tezos/messages/src/p2p/binary_message.rs
@@ -334,14 +334,16 @@ impl From<ser::Error> for MessageHashError {
 
 impl From<crypto::hash::FromBytesError> for MessageHashError {
     fn from(error: crypto::hash::FromBytesError) -> Self {
-        MessageHashError::FromBytesError{error}
+        MessageHashError::FromBytesError { error }
     }
 }
 
 /// Trait for getting hash of the message.
 pub trait MessageHash {
     fn message_hash(&self) -> Result<Hash, MessageHashError>;
-    fn message_typed_hash<H>(&self) -> Result<H, MessageHashError> where H: crypto::hash::HashTrait;
+    fn message_typed_hash<H>(&self) -> Result<H, MessageHashError>
+    where
+        H: crypto::hash::HashTrait;
 }
 
 impl<T: BinaryMessage + cache::CachedData> MessageHash for T {
@@ -353,7 +355,8 @@ impl<T: BinaryMessage + cache::CachedData> MessageHash for T {
 
     #[inline]
     fn message_typed_hash<H>(&self) -> Result<H, MessageHashError>
-    where H: crypto::hash::HashTrait
+    where
+        H: crypto::hash::HashTrait,
     {
         let bytes = self.as_bytes()?;
         let digest = blake2b::digest_256(&bytes);

--- a/tezos/messages/src/p2p/encoding/operation.rs
+++ b/tezos/messages/src/p2p/encoding/operation.rs
@@ -65,7 +65,7 @@ impl Operation {
 impl From<DecodedOperation> for Operation {
     fn from(dop: DecodedOperation) -> Operation {
         Operation {
-            branch: HashType::BlockHash.b58check_to_hash(&dop.branch).unwrap(),
+            branch: BlockHash::from_base58_check(&dop.branch).unwrap(),
             data: hex::decode(&dop.data).unwrap(),
             body: Default::default(),
         }
@@ -96,7 +96,7 @@ pub struct DecodedOperation {
 impl From<Operation> for DecodedOperation {
     fn from(op: Operation) -> DecodedOperation {
         DecodedOperation {
-            branch: HashType::BlockHash.hash_to_b58check(&op.branch()),
+            branch: op.branch().to_base58_check(),
             data: hex::encode(op.data()),
         }
     }

--- a/tezos/messages/src/protocol/mod.rs
+++ b/tezos/messages/src/protocol/mod.rs
@@ -9,7 +9,7 @@ use lazy_static::lazy_static;
 use strum::IntoEnumIterator;
 use strum_macros::EnumIter;
 
-use crypto::hash::{HashType, ProtocolHash};
+use crypto::hash::ProtocolHash;
 use tezos_encoding::binary_reader::BinaryReaderError;
 
 use crate::base::rpc_support::{RpcJsonMap, ToRpcJsonMap};
@@ -76,7 +76,7 @@ impl TryFrom<&ProtocolHash> for SupportedProtocol {
     type Error = UnsupportedProtocolError;
 
     fn try_from(protocol_hash: &ProtocolHash) -> Result<Self, Self::Error> {
-        let protocol = HashType::ProtocolHash.hash_to_b58check(protocol_hash);
+        let protocol = protocol_hash.to_base58_check();
         match SUPPORTED_PROTOCOLS.get(&protocol) {
             Some(proto) => Ok(proto.clone()),
             None => Err(UnsupportedProtocolError { protocol }),

--- a/tezos/messages/tests/encoding_block_header.rs
+++ b/tezos/messages/tests/encoding_block_header.rs
@@ -18,19 +18,19 @@ fn can_deserialize_block_header() -> Result<(), Error> {
     assert_eq!("000000000003c762c7df00a856b8bfcaf0676f069f825ca75f37f2bee9fe55ba109cec3d1d041d8c03519626c0c0faa557e778cb09d2e0c729e8556ed6a7a518c84982d1f2682bc6aa753f", &hex::encode(block_header.protocol_data()));
     assert_eq!(
         "BKoBK7Qa8J4Wvz85MDRWmpAntd5UhPhCh3p6Ga6woJywF8cZkeJ",
-        HashType::BlockHash.hash_to_b58check(&block_header.message_hash()?)
+        HashType::BlockHash.hash_to_b58check(&block_header.message_hash()?)?
     );
     assert_eq!(
         "BKjYUUtYXtXjEuL49jB8ZbFwVdg4hU6U7oKKSC5vp6stYsfFDVN",
-        HashType::BlockHash.hash_to_b58check(block_header.predecessor())
+        block_header.predecessor().to_base58_check()
     );
     assert_eq!(
         "LLoZi3xywrX9swZQgC82m7vj5hmuz6LGAatNq2Muh34oNn71JruZs",
-        HashType::OperationListListHash.hash_to_b58check(block_header.operations_hash())
+        block_header.operations_hash().to_base58_check()
     );
     Ok(assert_eq!(
         "CoUoqw1cVKUUNWyAviph5cdsjDpgeNhH2DGkMtgy7N6kfwnbewvS",
-        HashType::ContextHash.hash_to_b58check(block_header.context())
+        block_header.context().to_base58_check()
     ))
 }
 
@@ -48,7 +48,7 @@ fn can_deserialize_get_block_headers() -> Result<(), Error> {
             assert_eq!(1, message.get_block_headers().len());
             Ok(assert_eq!(
                 "BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET",
-                HashType::BlockHash.hash_to_b58check(message.get_block_headers().get(0).unwrap())
+                message.get_block_headers().get(0).unwrap().to_base58_check()
             ))
         }
         _ => panic!("Unsupported encoding: {:?}", message),

--- a/tezos/messages/tests/encoding_block_header.rs
+++ b/tezos/messages/tests/encoding_block_header.rs
@@ -48,7 +48,11 @@ fn can_deserialize_get_block_headers() -> Result<(), Error> {
             assert_eq!(1, message.get_block_headers().len());
             Ok(assert_eq!(
                 "BKyQ9EofHrgaZKENioHyP4FZNsTmiSEcVmcghgzCC9cGhE7oCET",
-                message.get_block_headers().get(0).unwrap().to_base58_check()
+                message
+                    .get_block_headers()
+                    .get(0)
+                    .unwrap()
+                    .to_base58_check()
             ))
         }
         _ => panic!("Unsupported encoding: {:?}", message),

--- a/tezos/messages/tests/encoding_constants.rs
+++ b/tezos/messages/tests/encoding_constants.rs
@@ -8,7 +8,7 @@ use assert_json_diff::assert_json_eq;
 use failure::Error;
 use serde_json::{json, Value};
 
-use crypto::hash::{HashType, ProtocolHash};
+use crypto::hash::ProtocolHash;
 use tezos_messages::base::rpc_support::{ToRpcJsonMap, UniversalValue};
 use tezos_messages::protocol::{
     get_constants_for_rpc, proto_005_2, proto_006, proto_007, proto_008, SupportedProtocol,
@@ -19,12 +19,11 @@ fn can_deserialize_constants_005_2() -> Result<(), Error> {
     // 005 data
     let just_dynamic_constants_bytes = hex::decode("030000080000000020000001000000080000000010000000000000001e0000000000000028002080d46180c8d00700003fffffffffff80a0d9e61d03e8c8d00700000101808092f40180a0c21e80c8d00780897ae807a0a907000000000000a8c000000bb800001b58000001f400180000000000000002")?;
     let expected_dynamic_constants_json = json!({"preserved_cycles":3,"blocks_per_cycle":2048,"blocks_per_commitment":32,"blocks_per_roll_snapshot":256,"blocks_per_voting_period":2048,"time_between_blocks":["30","40"],"endorsers_per_block":32,"hard_gas_limit_per_operation":"800000","hard_gas_limit_per_block":"8000000","proof_of_work_threshold":"70368744177663","tokens_per_roll":"8000000000","michelson_maximum_type_size":1000,"seed_nonce_revelation_tip":"125000","origination_size":257,"block_security_deposit":"512000000","endorsement_security_deposit":"64000000","block_reward":"16000000","endorsement_reward":"2000000","cost_per_byte":"1000","hard_storage_limit_per_operation":"60000","test_chain_duration":"43200","quorum_min":3000,"quorum_max":7000,"min_proposal_quorum":500,"initial_endorsers":24,"delay_per_missing_endorsement":"2"});
-    let protocol_hash = HashType::ProtocolHash.b58check_to_hash(proto_005_2::PROTOCOL_HASH)?;
+    let protocol_hash = ProtocolHash::try_from(proto_005_2::PROTOCOL_HASH)?;
     let expected_fixed_constants = proto_005_2::constants::FIXED.as_map();
 
     assert_constants_eq(
-        HashType::ProtocolHash
-            .b58check_to_hash("PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS")?,
+        ProtocolHash::try_from("PsBabyM1eUXZseaJdmXFApDSBqj8YBfwELoxZHHW77EMcAbbwAS")?,
         expected_dynamic_constants_json,
         expected_fixed_constants,
         protocol_hash,
@@ -37,12 +36,11 @@ fn can_deserialize_constants_006() -> Result<(), Error> {
     // 006 data
     let just_dynamic_constants_bytes = hex::decode("030000080000000020000001000000080000000010000000000000001e0000000000000028002080fa7e80c4f50900003fffffffffff80a0d9e61d03e8c8d007000001018088d54480d1ca0800000006d0a54cecb80b00000006d0a54cb5ee32e807a0a907000000000000a8c000000bb800001b58000001f400180000000000000002")?;
     let expected_dynamic_constants_json = json!({"preserved_cycles":3,"blocks_per_cycle":2048,"blocks_per_commitment":32,"blocks_per_roll_snapshot":256,"blocks_per_voting_period":2048,"time_between_blocks":["30","40"],"endorsers_per_block":32,"hard_gas_limit_per_operation":"1040000","hard_gas_limit_per_block":"10400000","proof_of_work_threshold":"70368744177663","tokens_per_roll":"8000000000","michelson_maximum_type_size":1000,"seed_nonce_revelation_tip":"125000","origination_size":257,"block_security_deposit":"144000000","endorsement_security_deposit":"18000000","baking_reward_per_endorsement":["1250000","187500"],"endorsement_reward":["1250000","833333"],"cost_per_byte":"1000","hard_storage_limit_per_operation":"60000","test_chain_duration":"43200","quorum_min":3000,"quorum_max":7000,"min_proposal_quorum":500,"initial_endorsers":24,"delay_per_missing_endorsement":"2"});
-    let protocol_hash = HashType::ProtocolHash.b58check_to_hash(proto_006::PROTOCOL_HASH)?;
+    let protocol_hash = ProtocolHash::try_from(proto_006::PROTOCOL_HASH)?;
     let expected_fixed_constants = proto_006::constants::FIXED.as_map();
 
     assert_constants_eq(
-        HashType::ProtocolHash
-            .b58check_to_hash("PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb")?,
+        ProtocolHash::try_from("PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb")?,
         expected_dynamic_constants_json,
         expected_fixed_constants,
         protocol_hash,
@@ -55,12 +53,11 @@ fn can_deserialize_constants_007() -> Result<(), Error> {
     // 007 data
     let just_dynamic_constants_bytes = hex::decode("030000080000000010000000800000080000000010000000000000001e0000000000000014002080fa7e80c4f50900003fffffffffff80a0d9e61d03e8c8d00700000101808092f40180a0c21e00000006d0a54cecb80b00000006d0a54cb5ee32fa01a0a907000000000000f000000007d000001b58000001f400180000000000000004")?;
     let expected_dynamic_constants_json = json!({"preserved_cycles":3,"blocks_per_cycle":2048,"blocks_per_commitment":16,"blocks_per_roll_snapshot":128,"blocks_per_voting_period":2048,"time_between_blocks":["30","20"],"endorsers_per_block":32,"hard_gas_limit_per_operation":"1040000","hard_gas_limit_per_block":"10400000","proof_of_work_threshold":"70368744177663","tokens_per_roll":"8000000000","michelson_maximum_type_size":1000,"seed_nonce_revelation_tip":"125000","origination_size":257,"block_security_deposit":"512000000","endorsement_security_deposit":"64000000","baking_reward_per_endorsement":["1250000","187500"],"endorsement_reward":["1250000","833333"],"cost_per_byte":"250","hard_storage_limit_per_operation":"60000","test_chain_duration":"61440","quorum_min":2000,"quorum_max":7000,"min_proposal_quorum":500,"initial_endorsers":24,"delay_per_missing_endorsement":"4"});
-    let protocol_hash = HashType::ProtocolHash.b58check_to_hash(proto_007::PROTOCOL_HASH)?;
+    let protocol_hash = ProtocolHash::try_from(proto_007::PROTOCOL_HASH)?;
     let expected_fixed_constants = proto_007::constants::FIXED.as_map();
 
     assert_constants_eq(
-        HashType::ProtocolHash
-            .b58check_to_hash("PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo")?,
+        ProtocolHash::try_from("PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo")?,
         expected_dynamic_constants_json,
         expected_fixed_constants,
         protocol_hash,
@@ -75,12 +72,11 @@ fn can_deserialize_constants_008() -> Result<(), Error> {
     let just_dynamic_constants_bytes = hex::decode("030000080000000010000000800000080000000010000000000000001e0000000000000014002080fa7e80c4f50900003fffffffffff80a0d9e61d03e8c8d00700000101808092f40180a0c21e00000006d0a54cecb80b00000006d0a54cb5ee32fa01a0a907000000000000f000000007d000001b58000001f400180000000000000004")?;
     // This, can be done: /chains/main/blocks/2/context/constants + removed fixed
     let expected_dynamic_constants_json = json!({"preserved_cycles":3,"blocks_per_cycle":2048,"blocks_per_commitment":16,"blocks_per_roll_snapshot":128,"blocks_per_voting_period":2048,"time_between_blocks":["30","20"],"endorsers_per_block":32,"hard_gas_limit_per_operation":"1040000","hard_gas_limit_per_block":"10400000","proof_of_work_threshold":"70368744177663","tokens_per_roll":"8000000000","michelson_maximum_type_size":1000,"seed_nonce_revelation_tip":"125000","origination_size":257,"block_security_deposit":"512000000","endorsement_security_deposit":"64000000","baking_reward_per_endorsement":["1250000","187500"],"endorsement_reward":["1250000","833333"],"cost_per_byte":"250","hard_storage_limit_per_operation":"60000","test_chain_duration":"61440","quorum_min":2000,"quorum_max":7000,"min_proposal_quorum":500,"initial_endorsers":24,"delay_per_missing_endorsement":"4"});
-    let protocol_hash = HashType::ProtocolHash.b58check_to_hash(proto_008::PROTOCOL_HASH)?;
+    let protocol_hash = ProtocolHash::try_from(proto_008::PROTOCOL_HASH)?;
     let expected_fixed_constants = proto_008::constants::FIXED.as_map();
 
     assert_constants_eq(
-        HashType::ProtocolHash
-            .b58check_to_hash("PtEdoTezd3RHSC31mpxxo1npxFjoWWcFgQtxapi51Z8TLu6v6Uq")?,
+        ProtocolHash::try_from("PtEdoTezd3RHSC31mpxxo1npxFjoWWcFgQtxapi51Z8TLu6v6Uq")?,
         expected_dynamic_constants_json,
         expected_fixed_constants,
         protocol_hash,

--- a/tezos/messages/tests/encoding_current_branch.rs
+++ b/tezos/messages/tests/encoding_current_branch.rs
@@ -47,7 +47,10 @@ fn can_deserialize_current_branch_message() -> Result<(), Error> {
 
     match message {
         PeerMessage::CurrentBranch(current_branch_message) => {
-            assert_eq!(&hex::decode("8eceda2f")?, current_branch_message.chain_id().as_ref());
+            assert_eq!(
+                &hex::decode("8eceda2f")?,
+                current_branch_message.chain_id().as_ref()
+            );
 
             let current_head = current_branch_message.current_branch().current_head();
             assert_eq!(198_392, current_head.level());

--- a/tezos/messages/tests/encoding_current_branch.rs
+++ b/tezos/messages/tests/encoding_current_branch.rs
@@ -1,6 +1,9 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use std::convert::TryFrom;
+
+use crypto::hash::ChainId;
 use failure::Error;
 use tezos_messages::p2p::binary_message::BinaryMessage;
 use tezos_messages::p2p::encoding::prelude::*;
@@ -27,7 +30,7 @@ fn can_deserialize_and_serialize_current_branch_message() {
 #[test]
 fn can_serialize_get_current_branch_message() {
     let get_current_branch_message = PeerMessage::GetCurrentBranch(GetCurrentBranchMessage::new(
-        hex::decode("8eceda2f").unwrap(),
+        ChainId::try_from(hex::decode("8eceda2f").unwrap()).unwrap(),
     ));
     let response: PeerMessageResponse = get_current_branch_message.into();
     let message_bytes = response.as_bytes().unwrap();
@@ -44,7 +47,7 @@ fn can_deserialize_current_branch_message() -> Result<(), Error> {
 
     match message {
         PeerMessage::CurrentBranch(current_branch_message) => {
-            assert_eq!(&hex::decode("8eceda2f")?, current_branch_message.chain_id());
+            assert_eq!(&hex::decode("8eceda2f")?, current_branch_message.chain_id().as_ref());
 
             let current_head = current_branch_message.current_branch().current_head();
             assert_eq!(198_392, current_head.level());
@@ -52,15 +55,15 @@ fn can_deserialize_current_branch_message() -> Result<(), Error> {
 
             assert_eq!(
                 &hex::decode("46a6aefde9243ae18b191a8d010b7237d5130b3530ce5d1f60457411b2fa632d")?,
-                current_head.predecessor()
+                current_head.predecessor().as_ref()
             );
             assert_eq!(
                 &hex::decode("934484026d24be9ad40c98341c20e51092dd62bbf470bb9ff85061fa981ebbd9")?,
-                current_head.context()
+                current_head.context().as_ref()
             );
             assert_eq!(
                 &hex::decode("acecbfac449678f1d68b90c7b7a86c9280fd373d872e072f3fb1b395681e7149")?,
-                current_head.operations_hash()
+                current_head.operations_hash().as_ref()
             );
 
             assert_eq!(2, current_head.fitness().len());

--- a/tezos/messages/tests/encoding_current_head.rs
+++ b/tezos/messages/tests/encoding_current_head.rs
@@ -10,7 +10,8 @@ use tezos_messages::p2p::encoding::prelude::*;
 
 #[test]
 fn can_serialize_get_current_head_message() -> Result<(), Error> {
-    let response: PeerMessageResponse = GetCurrentHeadMessage::new(ChainId::try_from(hex::decode("8eceda2f")?)?).into();
+    let response: PeerMessageResponse =
+        GetCurrentHeadMessage::new(ChainId::try_from(hex::decode("8eceda2f")?)?).into();
     let message_bytes = response.as_bytes().unwrap();
     let expected_writer_result = hex::decode("0000000600138eceda2f").expect("Failed to decode");
     Ok(assert_eq!(expected_writer_result, message_bytes))
@@ -25,7 +26,10 @@ fn can_deserialize_get_current_head_message_known_valid() -> Result<(), Error> {
 
     match message {
         PeerMessage::CurrentHead(current_head_message) => {
-            assert_eq!(&hex::decode("8eceda2f")?, current_head_message.chain_id().as_ref());
+            assert_eq!(
+                &hex::decode("8eceda2f")?,
+                current_head_message.chain_id().as_ref()
+            );
 
             let block_header = current_head_message.current_block_header();
             assert_eq!(245_395, block_header.level());
@@ -38,7 +42,10 @@ fn can_deserialize_get_current_head_message_known_valid() -> Result<(), Error> {
             assert_eq!(1, mempool.known_valid().len());
             let expected_known_valid =
                 hex::decode("c533d1d8a515b35fac67eb9926a6c983397208511ce69808d57177415654bf09")?;
-            assert_eq!(&expected_known_valid, mempool.known_valid().get(0).unwrap().as_ref());
+            assert_eq!(
+                &expected_known_valid,
+                mempool.known_valid().get(0).unwrap().as_ref()
+            );
             Ok(assert_eq!(0, mempool.pending().len()))
         }
         _ => panic!("Unsupported encoding: {:?}", message),
@@ -54,7 +61,10 @@ fn can_deserialize_get_current_head_message_pending() -> Result<(), Error> {
 
     match message {
         PeerMessage::CurrentHead(current_head_message) => {
-            assert_eq!(&hex::decode("8eceda2f")?, current_head_message.chain_id().as_ref());
+            assert_eq!(
+                &hex::decode("8eceda2f")?,
+                current_head_message.chain_id().as_ref()
+            );
 
             let block_header = current_head_message.current_block_header();
             assert_eq!(248_533, block_header.level());
@@ -68,7 +78,10 @@ fn can_deserialize_get_current_head_message_pending() -> Result<(), Error> {
             assert_eq!(2, mempool.pending().len());
             let expected_pending =
                 hex::decode("3cebec53e6ff9207dd669c3777cec4e74feadcd5f0131c819d261cdb0d9b5d94")?;
-            assert_eq!(&expected_pending, mempool.pending().get(0).unwrap().as_ref());
+            assert_eq!(
+                &expected_pending,
+                mempool.pending().get(0).unwrap().as_ref()
+            );
             let expected_pending =
                 hex::decode("70669010ec4053d96d750daefbcdc1f51ed79f9e29fb16931515eccb84cb6a55")?;
             Ok(assert_eq!(

--- a/tezos/messages/tests/encoding_deactivate.rs
+++ b/tezos/messages/tests/encoding_deactivate.rs
@@ -1,13 +1,16 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
+use std::convert::TryFrom;
+
+use crypto::hash::ChainId;
 use tezos_messages::p2p::binary_message::BinaryMessage;
 use tezos_messages::p2p::encoding::prelude::*;
 
 #[test]
 fn can_deserialize_deactivate_message() {
     let deactivate_message =
-        PeerMessage::Deactivate(DeactivateMessage::new(hex::decode("8eceda2f").unwrap()));
+        PeerMessage::Deactivate(DeactivateMessage::new(ChainId::try_from(hex::decode("8eceda2f").unwrap()).unwrap()));
     let resp: PeerMessageResponse = deactivate_message.into();
     let msg_bytes = resp.as_bytes().unwrap();
     let expected = hex::decode("0000000600128eceda2f").expect("Failed to decode");
@@ -17,7 +20,7 @@ fn can_deserialize_deactivate_message() {
 #[test]
 fn deserialized_equals_serialized_message() {
     let original_message =
-        PeerMessage::Deactivate(DeactivateMessage::new(hex::decode("8eceda2f").unwrap()));
+        PeerMessage::Deactivate(DeactivateMessage::new(ChainId::try_from(hex::decode("8eceda2f").unwrap()).unwrap()));
     let resp: PeerMessageResponse = original_message.into();
     let msg_bytes = resp.as_bytes().unwrap();
     let deserialized = PeerMessageResponse::from_bytes(msg_bytes).expect("expected valid message");
@@ -26,7 +29,7 @@ fn deserialized_equals_serialized_message() {
         .get(0)
         .expect("expected message in response");
     let original_message =
-        PeerMessage::Deactivate(DeactivateMessage::new(hex::decode("8eceda2f").unwrap()));
+        PeerMessage::Deactivate(DeactivateMessage::new(ChainId::try_from(hex::decode("8eceda2f").unwrap()).unwrap()));
 
     if let (PeerMessage::Deactivate(ref orig_msg), PeerMessage::Deactivate(ref des_msg)) =
         (original_message, deserialized_message)

--- a/tezos/messages/tests/encoding_deactivate.rs
+++ b/tezos/messages/tests/encoding_deactivate.rs
@@ -9,8 +9,9 @@ use tezos_messages::p2p::encoding::prelude::*;
 
 #[test]
 fn can_deserialize_deactivate_message() {
-    let deactivate_message =
-        PeerMessage::Deactivate(DeactivateMessage::new(ChainId::try_from(hex::decode("8eceda2f").unwrap()).unwrap()));
+    let deactivate_message = PeerMessage::Deactivate(DeactivateMessage::new(
+        ChainId::try_from(hex::decode("8eceda2f").unwrap()).unwrap(),
+    ));
     let resp: PeerMessageResponse = deactivate_message.into();
     let msg_bytes = resp.as_bytes().unwrap();
     let expected = hex::decode("0000000600128eceda2f").expect("Failed to decode");
@@ -19,8 +20,9 @@ fn can_deserialize_deactivate_message() {
 
 #[test]
 fn deserialized_equals_serialized_message() {
-    let original_message =
-        PeerMessage::Deactivate(DeactivateMessage::new(ChainId::try_from(hex::decode("8eceda2f").unwrap()).unwrap()));
+    let original_message = PeerMessage::Deactivate(DeactivateMessage::new(
+        ChainId::try_from(hex::decode("8eceda2f").unwrap()).unwrap(),
+    ));
     let resp: PeerMessageResponse = original_message.into();
     let msg_bytes = resp.as_bytes().unwrap();
     let deserialized = PeerMessageResponse::from_bytes(msg_bytes).expect("expected valid message");
@@ -28,8 +30,9 @@ fn deserialized_equals_serialized_message() {
         .messages()
         .get(0)
         .expect("expected message in response");
-    let original_message =
-        PeerMessage::Deactivate(DeactivateMessage::new(ChainId::try_from(hex::decode("8eceda2f").unwrap()).unwrap()));
+    let original_message = PeerMessage::Deactivate(DeactivateMessage::new(
+        ChainId::try_from(hex::decode("8eceda2f").unwrap()).unwrap(),
+    ));
 
     if let (PeerMessage::Deactivate(ref orig_msg), PeerMessage::Deactivate(ref des_msg)) =
         (original_message, deserialized_message)

--- a/tezos/messages/tests/encoding_operation.rs
+++ b/tezos/messages/tests/encoding_operation.rs
@@ -1,7 +1,6 @@
 // Copyright (c) SimpleStaking and Tezedge Contributors
 // SPDX-License-Identifier: MIT
 
-use crypto::hash::HashType;
 use failure::Error;
 use tezos_messages::p2p::binary_message::BinaryMessage;
 use tezos_messages::p2p::encoding::prelude::*;
@@ -12,7 +11,7 @@ fn can_deserialize() -> Result<(), Error> {
     let operation = Operation::from_bytes(message_bytes)?;
     assert_eq!(
         "BKqTKfGwK3zHnVXX33X5PPHy1FDTnbkajj3eFtCXGFyfimQhT1H",
-        HashType::BlockHash.hash_to_b58check(&operation.branch())
+        operation.branch().to_base58_check()
     );
     Ok(assert_eq!("000008c387fa065a181d45d47a9b78ddc77e92a881779ff2cbabbf9646eade4bf1405a08e00b725ed849eea46953b10b5cdebc518e6fd47e69b82d2ca18c4cf6d2f312dd08", &hex::encode(&operation.data())))
 }

--- a/tezos/messages/tests/encoding_operations_for_blocks.rs
+++ b/tezos/messages/tests/encoding_operations_for_blocks.rs
@@ -45,13 +45,17 @@ fn can_deserialize_operations_for_blocks_right() -> Result<(), Error> {
                 Path::Right(path) => {
                     assert_eq!(
                         "LLobFmsoFEGPP3q9ZxpE84rH1vPC1uKqEV8L1x8zUjGwanEYuHBVB",
-                                HashType::OperationListListHash.hash_to_b58check(path.left()).unwrap()
+                        HashType::OperationListListHash
+                            .hash_to_b58check(path.left())
+                            .unwrap()
                     );
                     match path.path() {
                         Path::Right(path) => {
                             assert_eq!(
                                 "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc",
-                                HashType::OperationListListHash.hash_to_b58check(path.left()).unwrap()
+                                HashType::OperationListListHash
+                                    .hash_to_b58check(path.left())
+                                    .unwrap()
                             );
                             match path.path() {
                                 Path::Op => Ok(()),
@@ -94,13 +98,17 @@ fn can_deserialize_operations_for_blocks_left() -> Result<(), Error> {
                 Path::Left(path) => {
                     assert_eq!(
                         "LLoZQD2o1hNgoUhg6ha9dCVyRUY25GX1KN2TttXW2PZsyS8itbfpK",
-                        HashType::OperationListListHash.hash_to_b58check(path.right()).unwrap()
+                        HashType::OperationListListHash
+                            .hash_to_b58check(path.right())
+                            .unwrap()
                     );
                     match path.path() {
                         Path::Left(path) => {
                             assert_eq!(
                                 "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc",
-                                HashType::OperationListListHash.hash_to_b58check(path.right()).unwrap()
+                                HashType::OperationListListHash
+                                    .hash_to_b58check(path.right())
+                                    .unwrap()
                             );
                             match path.path() {
                                 Path::Op => Ok(()),

--- a/tezos/messages/tests/encoding_operations_for_blocks.rs
+++ b/tezos/messages/tests/encoding_operations_for_blocks.rs
@@ -19,7 +19,7 @@ fn can_deserialize_get_operations_for_blocks() -> Result<(), Error> {
             assert_eq!(4, operations.len());
             assert_eq!(
                 "BMWmj9CTojf7AnA8ZQFWGkh1cXB6FkST8Ey5coaeHX6cVNAZqA6",
-                HashType::BlockHash.hash_to_b58check(operations[0].hash())
+                operations[0].hash().to_base58_check()
             );
             Ok(assert_eq!(1, operations[0].validation_pass()))
         }
@@ -38,20 +38,20 @@ fn can_deserialize_operations_for_blocks_right() -> Result<(), Error> {
         PeerMessage::OperationsForBlocks(message) => {
             assert_eq!(
                 "BM4Hyf4ay3u2PcUBmumTEPcWW8Z7t45HXGZAjLNnenSC2f8bLte",
-                HashType::BlockHash.hash_to_b58check(message.operations_for_block().hash())
+                message.operations_for_block().hash().to_base58_check()
             );
 
             match message.operation_hashes_path() {
                 Path::Right(path) => {
                     assert_eq!(
                         "LLobFmsoFEGPP3q9ZxpE84rH1vPC1uKqEV8L1x8zUjGwanEYuHBVB",
-                        HashType::OperationListListHash.hash_to_b58check(path.left())
+                                HashType::OperationListListHash.hash_to_b58check(path.left()).unwrap()
                     );
                     match path.path() {
                         Path::Right(path) => {
                             assert_eq!(
                                 "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc",
-                                HashType::OperationListListHash.hash_to_b58check(path.left())
+                                HashType::OperationListListHash.hash_to_b58check(path.left()).unwrap()
                             );
                             match path.path() {
                                 Path::Op => Ok(()),
@@ -82,7 +82,7 @@ fn can_deserialize_operations_for_blocks_left() -> Result<(), Error> {
         PeerMessage::OperationsForBlocks(message) => {
             assert_eq!(
                 "BL61qJKRdXg6i628H62DyDqBNotK7f6CZrHGv4k7jEe8a86B7n8",
-                HashType::BlockHash.hash_to_b58check(message.operations_for_block().hash())
+                message.operations_for_block().hash().to_base58_check()
             );
             assert_eq!(
                 5,
@@ -94,13 +94,13 @@ fn can_deserialize_operations_for_blocks_left() -> Result<(), Error> {
                 Path::Left(path) => {
                     assert_eq!(
                         "LLoZQD2o1hNgoUhg6ha9dCVyRUY25GX1KN2TttXW2PZsyS8itbfpK",
-                        HashType::OperationListListHash.hash_to_b58check(path.right())
+                        HashType::OperationListListHash.hash_to_b58check(path.right()).unwrap()
                     );
                     match path.path() {
                         Path::Left(path) => {
                             assert_eq!(
                                 "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc",
-                                HashType::OperationListListHash.hash_to_b58check(path.right())
+                                HashType::OperationListListHash.hash_to_b58check(path.right()).unwrap()
                             );
                             match path.path() {
                                 Path::Op => Ok(()),


### PR DESCRIPTION
The general idea is to have distinct types for each hash type so we are sure we can safely use them only in correct APIs. Also that makes safe to calculate base58 encoding.

There are some questions still.
- From/ToOCaml. `ChainId` used to be represented as OCamlBytes, now it is more like other hashes.
-  `context_listener.rs` uses untyped hash (it does not use hash.rs from crypto crate), and there is a new function that convert that hash into typed one. We need to see if that might affect performance as new vector is allocated there on each hash.
- `tezos/client/src/client.rs` still uses RustBytes for hashes
- `PublicKey::publick_key_hash()` has new `unreachable()` since it can't fail with encoding.
- `SignaturePublicKeyHash` and `SignaturePublicKey` used to have `from_hex_hash_and_curve` that for some reason converts bytes to base58 and then back. 

This also fixes TE-267.