### PR TITLE
[TE-268] Remove assert from base58 to hash

### DIFF
--- a/crypto/src/base58.rs
+++ b/crypto/src/base58.rs
@@ -20,6 +20,11 @@ pub enum FromBase58CheckError {
     /// Data is too long
     #[fail(display = "data too long")]
     DataTooLong,
+    #[fail(
+        display = "mismatched data lenght: expected {}, actual {}",
+        expected, actual
+    )]
+    MismatchedLength { expected: usize, actual: usize },
 }
 
 /// Possible errors for ToBase58Check


### PR DESCRIPTION
Replace `assert_eq!` with error reporting.

This PR is built on top of the #387