### PR TITLE
Replace recursive linked list with vector [TE-384,TE-232]

### DIFF
--- a/storage/tests/operations_storage.rs
+++ b/storage/tests/operations_storage.rs
@@ -21,37 +21,37 @@ fn test_get_operations() -> Result<(), Error> {
     let storage = OperationsStorage::new(tmp_storage.storage());
     let message = OperationsForBlocksMessage::new(
         OperationsForBlock::new(block_hash_1.clone(), 3),
-        Path::Op,
+        Path::op(),
         vec![],
     );
     storage.put_operations(&message)?;
     let message = OperationsForBlocksMessage::new(
         OperationsForBlock::new(block_hash_1.clone(), 1),
-        Path::Op,
+        Path::op(),
         vec![],
     );
     storage.put_operations(&message)?;
     let message = OperationsForBlocksMessage::new(
         OperationsForBlock::new(block_hash_1.clone(), 0),
-        Path::Op,
+        Path::op(),
         vec![],
     );
     storage.put_operations(&message)?;
     let message = OperationsForBlocksMessage::new(
         OperationsForBlock::new(block_hash_2.clone(), 1),
-        Path::Op,
+        Path::op(),
         vec![],
     );
     storage.put_operations(&message)?;
     let message = OperationsForBlocksMessage::new(
         OperationsForBlock::new(block_hash_1.clone(), 2),
-        Path::Op,
+        Path::op(),
         vec![],
     );
     storage.put_operations(&message)?;
     let message = OperationsForBlocksMessage::new(
         OperationsForBlock::new(block_hash_3.clone(), 3),
-        Path::Op,
+        Path::op(),
         vec![],
     );
     storage.put_operations(&message)?;

--- a/tezos/api/src/ocaml_conv/from_ocaml.rs
+++ b/tezos/api/src/ocaml_conv/from_ocaml.rs
@@ -4,9 +4,9 @@
 use std::convert::TryFrom;
 
 use super::{
-    FfiPath, OCamlBlockHash, OCamlBlockMetadataHash, OCamlChainId, OCamlContextHash, OCamlHash,
-    OCamlOperationHash, OCamlOperationMetadataHash, OCamlOperationMetadataListListHash,
-    OCamlProtocolHash,
+    FfiPath, FfiPathLeft, FfiPathRight, OCamlBlockHash, OCamlBlockMetadataHash, OCamlChainId,
+    OCamlContextHash, OCamlHash, OCamlOperationHash, OCamlOperationMetadataHash,
+    OCamlOperationMetadataListListHash, OCamlProtocolHash,
 };
 use crate::ffi::{
     Applied, ApplyBlockResponse, BeginApplicationResponse, Errored, ForkingTestchainData,
@@ -22,7 +22,6 @@ use ocaml_interop::{
     impl_from_ocaml_record, impl_from_ocaml_variant, FromOCaml, OCaml, OCamlBytes, OCamlInt,
     OCamlInt32, OCamlList, ToRust,
 };
-use tezos_messages::p2p::encoding::operations_for_blocks::{Path, PathLeft, PathRight};
 
 macro_rules! from_ocaml_hash {
     ($ocaml_name:ident, $rust_name:ident) => {
@@ -197,27 +196,25 @@ impl_from_ocaml_variant! {
 
 // TODO: remove this after TE-207 has been solved
 impl_from_ocaml_variant! {
-    Path => FfiPath {
-        Left(path: Path, right: OCamlHash) => {
+    FfiPath => FfiPath {
+        Left(path: FfiPath, right: OCamlHash) => {
             let path: FfiPath = path;
-            FfiPath(
-                Path::Left(
-                    Box::new(
-                        PathLeft::new(
-                            path.0,
-                            right,
-                            Default::default()))))
+            FfiPath::Left(
+                Box::new(
+                    FfiPathLeft {
+                        path,
+                        right,
+                    }))
         },
-        Right(left: OCamlHash, path: Path) => {
+        Right(left: OCamlHash, path: FfiPath) => {
             let path: FfiPath = path;
-            FfiPath(
-                Path::Right(
-                    Box::new(
-                        PathRight::new(
-                            left,
-                            path.0,
-                            Default::default()))))
+            FfiPath::Right(
+                Box::new(
+                    FfiPathRight {
+                        left,
+                        path,
+                    }))
         },
-        Op => FfiPath(Path::Op),
+        Op => FfiPath::Op,
     }
 }

--- a/tezos/api/src/ocaml_conv/mod.rs
+++ b/tezos/api/src/ocaml_conv/mod.rs
@@ -2,17 +2,29 @@
 // SPDX-License-Identifier: MIT
 
 use crypto::hash::Hash;
-use tezos_messages::p2p::encoding::{
-    block_header::{Fitness, Level},
-    operations_for_blocks::Path,
-};
+use tezos_messages::p2p::encoding::block_header::{Fitness, Level};
 
 // FFI Wrappers:
 // Defined to be able to implement ToOCaml/FromOCaml traits for
 // structs that are defined in another crate and/or do not map directly
 // to the matching OCaml struct.
 
-pub struct FfiPath(pub Path);
+pub struct FfiPathRight {
+    pub left: Hash,
+    pub path: FfiPath,
+}
+
+pub struct FfiPathLeft {
+    pub path: FfiPath,
+    pub right: Hash,
+}
+
+pub enum FfiPath {
+    Right(Box<FfiPathRight>),
+    Left(Box<FfiPathLeft>),
+    Op,
+}
+
 pub struct FfiBlockHeader<'a> {
     shell: FfiBlockHeaderShellHeader<'a>,
     protocol_data: &'a Vec<u8>,

--- a/tezos/client/benches/bench_apply_first_three_blocks.rs
+++ b/tezos/client/benches/bench_apply_first_three_blocks.rs
@@ -229,7 +229,7 @@ mod test_data {
                         hex::decode(block_hash).unwrap().try_into().unwrap(),
                         4,
                     ),
-                    Path::Op,
+                    Path::op(),
                     ops,
                 )
             })

--- a/tezos/client/tests/bootstrap_storage_protocol_v1_test.rs
+++ b/tezos/client/tests/bootstrap_storage_protocol_v1_test.rs
@@ -998,7 +998,7 @@ mod test_data_protocol_v1 {
                         hex::decode(block_hash).unwrap().try_into().unwrap(),
                         4,
                     ),
-                    Path::Op,
+                    Path::op(),
                     ops,
                 )
             })

--- a/tezos/client/tests/bootstrap_storage_test.rs
+++ b/tezos/client/tests/bootstrap_storage_test.rs
@@ -697,7 +697,7 @@ mod test_data {
                         BlockHash::try_from(hex::decode(block_hash).unwrap()).unwrap(),
                         4,
                     ),
-                    Path::Op,
+                    Path::op(),
                     ops,
                 )
             })

--- a/tezos/client/tests/prevalidator_mempool_protocol_v1_test.rs
+++ b/tezos/client/tests/prevalidator_mempool_protocol_v1_test.rs
@@ -234,7 +234,7 @@ mod test_data_protocol_v1 {
                         BlockHash::try_from(hex::decode(block_hash).unwrap()).unwrap(),
                         4,
                     ),
-                    Path::Op,
+                    Path::op(),
                     ops,
                 )
             })

--- a/tezos/client/tests/prevalidator_mempool_test.rs
+++ b/tezos/client/tests/prevalidator_mempool_test.rs
@@ -213,7 +213,7 @@ mod test_data {
                         hex::decode(block_hash).unwrap().try_into().unwrap(),
                         4,
                     ),
-                    Path::Op,
+                    Path::op(),
                     ops,
                 )
             })

--- a/tezos/encoding/src/binary_reader.rs
+++ b/tezos/encoding/src/binary_reader.rs
@@ -29,15 +29,12 @@ pub enum BinaryReaderError {
     /// may simply mean that we have not yet defined tag in encoding.
     #[fail(display = "No tag found for id: 0x{:X}", tag)]
     UnsupportedTag { tag: u16 },
-    /// Enclosing level for recursive type value is too big
+    /// Encoding boundary constraint violation
     #[fail(
-        display = "Recursive data depth is too big for {}, max is {}",
-        name, max
+        display = "Encoded data {} exceeded its size boundary: {}",
+        name, boundary
     )]
-    RecursiveDataOverflow {
-        name: String,
-        max: crate::types::RecursiveDataSize,
-    },
+    EncodingBoundaryExceeded { name: String, boundary: usize },
 }
 
 impl From<crate::de::Error> for BinaryReaderError {

--- a/tezos/encoding/src/types.rs
+++ b/tezos/encoding/src/types.rs
@@ -125,7 +125,3 @@ pub enum Value {
     /// Tuple is heterogeneous collection of values, it should have fixed amount of elements
     Tuple(Vec<Value>),
 }
-
-/// Type for representing recursive data depth
-/// Currently u16 for compatibility with [Uint8](tezos_encoding::types::Value::Uint16)
-pub type RecursiveDataSize = u16;

--- a/tezos/interop/benches/interop_benchmark.rs
+++ b/tezos/interop/benches/interop_benchmark.rs
@@ -59,7 +59,7 @@ fn block_operations_from_hex(
                 .collect();
             OperationsForBlocksMessage::new(
                 OperationsForBlock::new(hex::decode(block_hash).unwrap().try_into().unwrap(), 4),
-                Path::Op,
+                Path::op(),
                 ops,
             )
         })

--- a/tezos/interop/tests/test_rust_ocaml_conv.rs
+++ b/tezos/interop/tests/test_rust_ocaml_conv.rs
@@ -135,7 +135,7 @@ fn block_operations_from_hex(
                     BlockHash::try_from(hex::decode(block_hash).unwrap()).unwrap(),
                     4,
                 ),
-                Path::Op,
+                Path::op(),
                 ops,
             )
         })

--- a/tezos/messages/src/p2p/encoding/mod.rs
+++ b/tezos/messages/src/p2p/encoding/mod.rs
@@ -36,7 +36,7 @@ pub mod prelude {
     pub use super::operation_hashes_for_blocks::{
         GetOperationHashesForBlocksMessage, OperationHashesForBlocksMessage,
     };
-    pub use super::operations_for_blocks::PATH_MAX_DEPTH;
+    pub use super::operations_for_blocks::MAX_PASS_MERKLE_DEPTH;
     pub use super::operations_for_blocks::{
         GetOperationsForBlocksMessage, OperationsForBlock, OperationsForBlocksMessage, Path,
         PathLeft, PathRight,

--- a/tezos/messages/src/p2p/encoding/operations_for_blocks.rs
+++ b/tezos/messages/src/p2p/encoding/operations_for_blocks.rs
@@ -7,13 +7,13 @@ use std::sync::Arc;
 use bytes::Buf;
 
 use getset::{CopyGetters, Getters};
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 
 use crypto::hash::{BlockHash, Hash, HashType};
 use tezos_encoding::binary_reader::BinaryReaderError;
 use tezos_encoding::encoding::{CustomCodec, Encoding, Field, HasEncoding};
 use tezos_encoding::ser::Error;
-use tezos_encoding::types::{RecursiveDataSize, Value};
+use tezos_encoding::types::Value;
 use tezos_encoding::{has_encoding, safe};
 
 use crate::cached_data;
@@ -21,11 +21,18 @@ use crate::p2p::binary_message::cache::BinaryDataCache;
 use crate::p2p::encoding::operation::Operation;
 use tezos_encoding::json_writer::JsonWriter;
 
-/// Maximal depth for path to be decoded/encoded.
-/// Serde serialization is still recursive and can lead to stack overflow.
-/// This value can be handled by serde and still it is big enough.
-/// to handle 2 ** 512 elements tree.
-pub const PATH_MAX_DEPTH: RecursiveDataSize = 512;
+/// Maximal length for path in a Merkle tree for list of lists of operations.
+/// This is calculated from Tezos limit on that Operation_list_list size:
+///
+/// `let operation_max_pass = ref (Some 8) (* FIXME: arbitrary *)`
+///
+/// See https://gitlab.com/simplestaking/tezos/-/blob/master/src/lib_shell/distributed_db_message.ml#L65
+///
+/// A  Merkle tree for that list of lenght 8 will be 3 (log_2(8)) levels at most,
+/// thus any path should be 3 steps at most.
+///
+/// TODO: Implement mechanism for updating this, when Tezos implements this.
+pub const MAX_PASS_MERKLE_DEPTH: Option<usize> = Some(3);
 
 #[derive(Clone, Serialize, Deserialize, PartialEq, Debug, CopyGetters, Getters)]
 pub struct OperationsForBlock {
@@ -114,286 +121,62 @@ impl From<OperationsForBlocksMessage> for Vec<Operation> {
 }
 
 // -----------------------------------------------------------------------------------------------
-#[derive(Clone, Serialize, PartialEq, Debug, Getters)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Getters)]
 pub struct PathRight {
     #[get = "pub"]
     left: Hash,
-    #[get = "pub"]
-    path: Path,
-    /// Depth (lenght) of the path
-    #[serde(skip_serializing)]
-    depth: Option<RecursiveDataSize>,
     #[serde(skip_serializing)]
     body: BinaryDataCache,
 }
 
 cached_data!(PathRight, body);
-has_encoding!(PathRight, PATH_RIGHT_ENCODING, {
-    Encoding::Obj(vec![
-        Field::new("left", Encoding::Hash(HashType::OperationListListHash)),
-        Field::new("path", PathCodec::get_encoding()),
-    ])
-});
 
 impl PathRight {
-    pub fn new(left: Hash, path: Path, body: BinaryDataCache) -> Self {
-        let depth = path.depth().map(|d| d.checked_add(1)).flatten();
-        Self {
-            left,
-            path,
-            depth,
-            body,
-        }
-    }
-}
-
-/// Custom deserialization is needed to properly set `depth` field.
-/// See https://serde.rs/deserialize-struct.html
-impl<'de> Deserialize<'de> for PathRight {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        use serde::de::{self, Error, SeqAccess, Visitor};
-        use std::fmt;
-        enum Field {
-            Left,
-            Path,
-        }
-
-        impl<'de> Deserialize<'de> for Field {
-            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
-            where
-                D: de::Deserializer<'de>,
-            {
-                struct FieldVisitor;
-
-                impl<'de> Visitor<'de> for FieldVisitor {
-                    type Value = Field;
-
-                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                        formatter.write_str("`left` or `path`")
-                    }
-
-                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
-                    where
-                        E: de::Error,
-                    {
-                        match value {
-                            "left" => Ok(Field::Left),
-                            "path" => Ok(Field::Path),
-                            _ => Err(Error::unknown_field(value, FIELDS)),
-                        }
-                    }
-                }
-
-                deserializer.deserialize_identifier(FieldVisitor)
-            }
-        }
-
-        struct PathRightVisitor;
-
-        impl<'de> Visitor<'de> for PathRightVisitor {
-            type Value = PathRight;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct PathRight")
-            }
-
-            fn visit_seq<V>(self, mut seq: V) -> Result<PathRight, V::Error>
-            where
-                V: SeqAccess<'de>,
-            {
-                let path = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                let left = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                Ok(PathRight::new(path, left, Default::default()))
-            }
-
-            fn visit_map<V>(self, mut map: V) -> Result<PathRight, V::Error>
-            where
-                V: de::MapAccess<'de>,
-            {
-                let mut path = None;
-                let mut left = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::Left => {
-                            if left.is_some() {
-                                return Err(de::Error::duplicate_field("left"));
-                            }
-                            left = Some(map.next_value()?);
-                        }
-                        Field::Path => {
-                            if path.is_some() {
-                                return Err(de::Error::duplicate_field("path"));
-                            }
-                            path = Some(map.next_value()?);
-                        }
-                    }
-                }
-                let left = left.ok_or_else(|| serde::de::Error::missing_field("left"))?;
-                let path = path.ok_or_else(|| serde::de::Error::missing_field("path"))?;
-                Ok(PathRight::new(left, path, Default::default()))
-            }
-        }
-
-        const FIELDS: &'static [&'static str] = &["path", "left"];
-        deserializer.deserialize_struct("PathRight", FIELDS, PathRightVisitor)
+    pub fn new(left: Hash, body: BinaryDataCache) -> Self {
+        Self { left, body }
     }
 }
 
 // -----------------------------------------------------------------------------------------------
-#[derive(Clone, Serialize, PartialEq, Debug, Getters)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Getters)]
 pub struct PathLeft {
     #[get = "pub"]
-    path: Path,
-    #[get = "pub"]
     right: Hash,
-    /// Depth (lenght) of the path
-    #[serde(skip_serializing)]
-    depth: Option<RecursiveDataSize>,
     #[serde(skip_serializing)]
     body: BinaryDataCache,
 }
 
 cached_data!(PathLeft, body);
-has_encoding!(PathLeft, PATH_LEFT_ENCODING, {
-    Encoding::Obj(vec![
-        Field::new("path", PathCodec::get_encoding()),
-        Field::new("right", Encoding::Hash(HashType::OperationListListHash)),
-    ])
-});
 
 impl PathLeft {
-    pub fn new(path: Path, right: Hash, body: BinaryDataCache) -> Self {
-        let depth = path.depth().map(|d| d.checked_add(1)).flatten();
-        Self {
-            path,
-            right,
-            depth,
-            body,
-        }
+    pub fn new(right: Hash, body: BinaryDataCache) -> Self {
+        Self { right, body }
     }
 }
 
-/// Custom deserialization is needed to properly set `depth` field.
-/// See https://serde.rs/deserialize-struct.html
-impl<'de> Deserialize<'de> for PathLeft {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::de::Deserializer<'de>,
-    {
-        use serde::de::{self, Error, SeqAccess, Visitor};
-        use std::fmt;
-        enum Field {
-            Path,
-            Right,
-        }
+// -----------------------------------------------------------------------------------------------
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+pub enum PathItem {
+    Right(PathRight),
+    Left(PathLeft),
+}
 
-        impl<'de> Deserialize<'de> for Field {
-            fn deserialize<D>(deserializer: D) -> Result<Field, D::Error>
-            where
-                D: de::Deserializer<'de>,
-            {
-                struct FieldVisitor;
-
-                impl<'de> Visitor<'de> for FieldVisitor {
-                    type Value = Field;
-
-                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                        formatter.write_str("`path` or `right`")
-                    }
-
-                    fn visit_str<E>(self, value: &str) -> Result<Field, E>
-                    where
-                        E: de::Error,
-                    {
-                        match value {
-                            "path" => Ok(Field::Path),
-                            "right" => Ok(Field::Right),
-                            _ => Err(Error::unknown_field(value, FIELDS)),
-                        }
-                    }
-                }
-
-                deserializer.deserialize_identifier(FieldVisitor)
-            }
-        }
-
-        struct PathLeftVisitor;
-
-        impl<'de> Visitor<'de> for PathLeftVisitor {
-            type Value = PathLeft;
-
-            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                formatter.write_str("struct PathLeft")
-            }
-
-            fn visit_seq<V>(self, mut seq: V) -> Result<PathLeft, V::Error>
-            where
-                V: SeqAccess<'de>,
-            {
-                let path = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(0, &self))?;
-                let right = seq
-                    .next_element()?
-                    .ok_or_else(|| de::Error::invalid_length(1, &self))?;
-                Ok(PathLeft::new(path, right, Default::default()))
-            }
-
-            fn visit_map<V>(self, mut map: V) -> Result<PathLeft, V::Error>
-            where
-                V: de::MapAccess<'de>,
-            {
-                let mut path = None;
-                let mut right = None;
-                while let Some(key) = map.next_key()? {
-                    match key {
-                        Field::Path => {
-                            if path.is_some() {
-                                return Err(de::Error::duplicate_field("path"));
-                            }
-                            path = Some(map.next_value()?);
-                        }
-                        Field::Right => {
-                            if right.is_some() {
-                                return Err(de::Error::duplicate_field("right"));
-                            }
-                            right = Some(map.next_value()?);
-                        }
-                    }
-                }
-                let path = path.ok_or_else(|| serde::de::Error::missing_field("path"))?;
-                let right = right.ok_or_else(|| serde::de::Error::missing_field("right"))?;
-                Ok(PathLeft::new(path, right, Default::default()))
-            }
-        }
-
-        const FIELDS: &'static [&'static str] = &["path", "right"];
-        deserializer.deserialize_struct("PathLeft", FIELDS, PathLeftVisitor)
+impl PathItem {
+    pub fn right(left: Hash) -> PathItem {
+        PathItem::Right(PathRight::new(left, Default::default()))
+    }
+    pub fn left(right: Hash) -> PathItem {
+        PathItem::Left(PathLeft::new(right, Default::default()))
     }
 }
 
 // -----------------------------------------------------------------------------------------------
 #[derive(Clone, Deserialize, PartialEq, Debug)]
-pub enum Path {
-    Left(Box<PathLeft>),
-    Right(Box<PathRight>),
-    Op,
-}
+pub struct Path(pub Vec<PathItem>);
 
 impl Path {
-    fn depth(&self) -> Option<RecursiveDataSize> {
-        match self {
-            Path::Left(l) => l.depth,
-            Path::Right(r) => r.depth,
-            Path::Op => Some(0),
-        }
+    pub fn op() -> Self {
+        Path(Vec::new())
     }
 }
 
@@ -401,23 +184,29 @@ impl Path {
 impl Serialize for Path {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
-        match self.depth() {
-            Some(d) if d <= PATH_MAX_DEPTH => (),
-            _ => {
-                use serde::ser::Error;
-                return Err(Error::custom("Path is too deep"));
+        match MAX_PASS_MERKLE_DEPTH {
+            Some(max) => {
+                if self.0.len() > max {
+                    use serde::ser::Error;
+                    return Err(Error::custom(format!(
+                        "Path size exceedes its boundary {} for encoding",
+                        max
+                    )));
+                }
             }
+            _ => (),
         }
-        match self {
-            Path::Left(h) => serializer.serialize_newtype_variant("Path", 0, "Left", h),
-            Path::Right(h) => serializer.serialize_newtype_variant("Path", 1, "Right", h),
-            Path::Op => serializer.serialize_unit_variant("Path", 2, "Op"),
-        }
+        use serde::ser::SerializeSeq;
+        let mut seq = serializer.serialize_seq(Some(self.0.len()))?;
+        self.0
+            .iter()
+            .map(|i| seq.serialize_element(i))
+            .collect::<Result<_, _>>()?;
+        seq.end()
     }
 }
-
 // -----------------------------------------------------------------------------------------------
 #[derive(Serialize, Deserialize, Debug, Getters, Clone)]
 pub struct GetOperationsForBlocksMessage {
@@ -501,21 +290,17 @@ impl PathCodec {
         Ok(())
     }
 
-    fn encode_left<'a>(
+    fn encode_left(
         data: &mut Vec<u8>,
-        tail: &mut VecDeque<Vec<u8>>,
-        value: &'a Value,
+        value: &Value,
         encoding: &Encoding,
-    ) -> Result<Option<&'a Value>, Error> {
+    ) -> Result<Option<Vec<u8>>, Error> {
         match value {
-            Value::Record(fields)
-                if fields.len() == 2 && fields[0].0 == "path" && fields[1].0 == "right" =>
-            {
+            Value::Record(fields) if fields.len() == 1 && fields[0].0 == "right" => {
                 data.push(0xF0);
                 let mut hash = Vec::new();
-                Self::encode_bytes(&mut hash, &fields[1].1, encoding)?;
-                tail.push_front(hash);
-                Ok(Some(&fields[0].1))
+                Self::encode_bytes(&mut hash, &fields[0].1, encoding)?;
+                Ok(Some(hash))
             }
             _ => Err(Error::encoding_mismatch(encoding, value)),
         }
@@ -525,33 +310,29 @@ impl PathCodec {
         json_writer: &mut JsonWriter,
         value: &'a Value,
         encoding: &Encoding,
-    ) -> Result<Option<(&'a Value, Option<&'a Value>)>, Error> {
+    ) -> Result<Option<&'a Value>, Error> {
         match value {
-            Value::Record(fields)
-                if fields.len() == 2 && fields[0].0 == "path" && fields[1].0 == "right" =>
-            {
+            Value::Record(fields) if fields.len() == 2 && fields[0].0 == "right" => {
                 json_writer.open_record();
                 json_writer.push_key("path");
                 json_writer.open_record();
 
-                Ok(Some((&fields[0].1, Some(&fields[1].1))))
+                Ok(Some(&fields[0].1))
             }
             _ => Err(Error::encoding_mismatch(encoding, value)),
         }
     }
 
-    fn encode_right<'a>(
+    fn encode_right(
         data: &mut Vec<u8>,
-        value: &'a Value,
+        value: &Value,
         encoding: &Encoding,
-    ) -> Result<Option<&'a Value>, Error> {
+    ) -> Result<Option<Vec<u8>>, Error> {
         match value {
-            Value::Record(fields)
-                if fields.len() == 2 && fields[0].0 == "left" && fields[1].0 == "path" =>
-            {
+            Value::Record(fields) if fields.len() == 1 && fields[0].0 == "left" => {
                 data.push(0x0F);
                 Self::encode_bytes(data, &fields[0].1, encoding)?;
-                Ok(Some(&fields[1].1))
+                Ok(None)
             }
             _ => Err(Error::encoding_mismatch(encoding, value)),
         }
@@ -561,58 +342,38 @@ impl PathCodec {
         json_writer: &mut JsonWriter,
         value: &'a Value,
         encoding: &Encoding,
-    ) -> Result<Option<(&'a Value, Option<&'a Value>)>, Error> {
+    ) -> Result<Option<&'a Value>, Error> {
         match value {
-            Value::Record(fields)
-                if fields.len() == 2 && fields[0].0 == "left" && fields[1].0 == "path" =>
-            {
+            Value::Record(fields) if fields.len() == 2 && fields[0].0 == "left" => {
                 json_writer.open_record();
                 json_writer.push_key("left");
                 Self::json_bytes(json_writer, &fields[0].1, encoding)?;
                 json_writer.push_delimiter();
                 json_writer.push_key("path");
                 json_writer.open_record();
-                Ok(Some((&fields[1].1, None)))
+                Ok(None)
             }
             _ => Err(Error::encoding_mismatch(encoding, value)),
         }
     }
 
-    fn encode_op<'a>(data: &mut Vec<u8>) -> Result<Option<&'a Value>, Error> {
-        data.push(0x00);
-        Ok(None)
-    }
-
-    fn json_op<'a>(
-        json_writer: &mut JsonWriter,
-    ) -> Result<Option<(&'a Value, Option<&'a Value>)>, Error> {
-        json_writer.push_str("Op");
-        Ok(None)
-    }
-
-    fn encode_path<'a>(
+    fn encode_path_item(
         data: &mut Vec<u8>,
-        tail: &mut VecDeque<Vec<u8>>,
+        value: &Value,
+        encoding: &Encoding,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        match value {
+            Value::Tag(name, inner) if name == "Left" => Self::encode_left(data, inner, encoding),
+            Value::Tag(name, inner) if name == "Right" => Self::encode_right(data, inner, encoding),
+            _ => Err(Error::encoding_mismatch(encoding, value)),
+        }
+    }
+
+    fn json_path_item<'a>(
+        json_writer: &mut JsonWriter,
         value: &'a Value,
         encoding: &Encoding,
     ) -> Result<Option<&'a Value>, Error> {
-        match value {
-            Value::Tag(name, inner) if name == "Left" => {
-                Self::encode_left(data, tail, inner, encoding)
-            }
-            Value::Tag(name, inner) if name == "Right" => Self::encode_right(data, inner, encoding),
-            Value::Enum(Some(name), Some(ord)) if name == "Op" && *ord == 2 => {
-                Self::encode_op(data)
-            }
-            _ => Err(Error::encoding_mismatch(encoding, value)),
-        }
-    }
-
-    fn json_path<'a>(
-        json_writer: &mut JsonWriter,
-        value: &'a Value,
-        encoding: &Encoding,
-    ) -> Result<Option<(&'a Value, Option<&'a Value>)>, Error> {
         match value {
             Value::Tag(name, inner) if name == "Left" => {
                 Self::json_left(json_writer, inner, encoding)
@@ -620,38 +381,31 @@ impl PathCodec {
             Value::Tag(name, inner) if name == "Right" => {
                 Self::json_right(json_writer, inner, encoding)
             }
-            Value::Enum(Some(name), Some(ord)) if name == "Op" && *ord == 2 => {
-                Self::json_op(json_writer)
-            }
             _ => Err(Error::encoding_mismatch(encoding, value)),
         }
-    }
-
-    fn mk_op() -> Value {
-        Value::Tag("Op".to_string(), Box::new(Value::Unit))
     }
 
     fn mk_list(bytes: &[u8]) -> Value {
         Value::List(bytes.iter().map(|b| Value::Uint8(*b)).collect())
     }
 
-    fn mk_left(path: Value, right: &[u8]) -> Value {
+    fn mk_left(right: &[u8]) -> Value {
         Value::Tag(
             "Left".to_string(),
-            Box::new(Value::Record(vec![
-                ("path".to_string(), path),
-                ("right".to_string(), Self::mk_list(right)),
-            ])),
+            Box::new(Value::Record(vec![(
+                "right".to_string(),
+                Self::mk_list(right),
+            )])),
         )
     }
 
-    fn mk_right(left: &[u8], path: Value) -> Value {
+    fn mk_right(left: &[u8]) -> Value {
         Value::Tag(
             "Right".to_string(),
-            Box::new(Value::Record(vec![
-                ("left".to_string(), Self::mk_list(left)),
-                ("path".to_string(), path),
-            ])),
+            Box::new(Value::Record(vec![(
+                "left".to_string(),
+                Self::mk_list(left),
+            )])),
         )
     }
 }
@@ -660,44 +414,55 @@ impl CustomCodec for PathCodec {
     fn encode(
         &self,
         data: &mut Vec<u8>,
-        mut value: &Value,
+        value: &Value,
         encoding: &Encoding,
     ) -> Result<usize, Error> {
-        let prev_size = data.len();
-        let mut tail = VecDeque::new();
-        while let Some(inner) = Self::encode_path(data, &mut tail, value, encoding)? {
-            value = inner;
+        if let Value::List(values) = value {
+            let prev_size = data.len();
+            let mut tails = VecDeque::new();
+            for path_item in values {
+                let tail = Self::encode_path_item(data, path_item, encoding)?;
+                tails.push_front(tail);
+            }
+            data.push(0x00);
+            data.extend(tails.into_iter().filter_map(|e| e).flatten());
+            data.len()
+                .checked_sub(prev_size)
+                .ok_or_else(|| Error::encoding_mismatch(encoding, value))
+        } else {
+            Err(Error::encoding_mismatch(encoding, value))
         }
-        data.extend(tail.into_iter().flatten());
-        data.len()
-            .checked_sub(prev_size)
-            .ok_or_else(|| Error::encoding_mismatch(encoding, value))
     }
 
     fn encode_json(
         &self,
         json_writer: &mut tezos_encoding::json_writer::JsonWriter,
-        mut value: &Value,
+        value: &Value,
         encoding: &Encoding,
     ) -> Result<(), Error> {
-        let mut tails = VecDeque::new();
-        while let Some((inner, tail)) = Self::json_path(json_writer, value, encoding)? {
-            value = inner;
-            tails.push_front(tail);
-        }
-        for tail in tails {
-            match tail {
-                Some(value) => {
-                    json_writer.push_delimiter();
-                    json_writer.push_key("right");
-                    Self::json_bytes(json_writer, value, encoding)?;
-                }
-                _ => {}
+        if let Value::List(values) = value {
+            let mut tails = VecDeque::new();
+            for path_item in values {
+                let tail = Self::json_path_item(json_writer, path_item, encoding)?;
+                tails.push_front(tail);
             }
-            json_writer.close_record();
-            json_writer.close_record();
+            json_writer.push_str("Op");
+            for tail in tails {
+                match tail {
+                    Some(value) => {
+                        json_writer.push_delimiter();
+                        json_writer.push_key("right");
+                        Self::json_bytes(json_writer, value, encoding)?;
+                    }
+                    _ => {}
+                }
+                json_writer.close_record();
+                json_writer.close_record();
+            }
+            Ok(())
+        } else {
+            Err(Error::encoding_mismatch(encoding, value))
         }
-        Ok(())
     }
 
     fn decode(&self, buf: &mut dyn Buf, _encoding: &Encoding) -> Result<Value, BinaryReaderError> {
@@ -717,29 +482,35 @@ impl CustomCodec for PathCodec {
                     nodes.push(PathNode::Right(hash.to_vec()));
                 }
                 0x00 => {
-                    let mut acc = Self::mk_op();
+                    let mut result = Vec::with_capacity(nodes.len());
                     for node in nodes.iter().rev() {
                         match node {
                             PathNode::Left => {
                                 safe!(buf, hash.len(), buf.copy_to_slice(&mut hash));
-                                acc = Self::mk_left(acc, &hash);
+                                result.push(Self::mk_left(&hash));
                             }
                             PathNode::Right(hash) => {
-                                acc = Self::mk_right(&hash, acc);
+                                result.push(Self::mk_right(&hash));
                             }
                         }
                     }
-                    return Ok(acc);
+                    result.reverse();
+                    return Ok(Value::List(result));
                 }
                 t => {
                     return Err(BinaryReaderError::UnsupportedTag { tag: t as u16 });
                 }
             }
-            if nodes.len() > PATH_MAX_DEPTH as usize {
-                return Err(BinaryReaderError::RecursiveDataOverflow {
-                    name: "Path".to_string(),
-                    max: PATH_MAX_DEPTH,
-                });
+            match MAX_PASS_MERKLE_DEPTH {
+                Some(max) => {
+                    if nodes.len() > max {
+                        return Err(BinaryReaderError::EncodingBoundaryExceeded {
+                            name: "Path".to_string(),
+                            boundary: max,
+                        });
+                    }
+                }
+                _ => (),
             }
         }
     }

--- a/tezos/messages/tests/encoding_operations_for_blocks.rs
+++ b/tezos/messages/tests/encoding_operations_for_blocks.rs
@@ -5,8 +5,11 @@ use std::convert::TryInto;
 
 use crypto::hash::HashType;
 use failure::Error;
-use tezos_messages::p2p::binary_message::{BinaryMessage, JsonMessage};
 use tezos_messages::p2p::encoding::prelude::*;
+use tezos_messages::p2p::{
+    binary_message::{BinaryMessage, JsonMessage},
+    encoding::operations_for_blocks::PathItem,
+};
 
 #[test]
 fn can_deserialize_get_operations_for_blocks() -> Result<(), Error> {
@@ -43,35 +46,37 @@ fn can_deserialize_operations_for_blocks_right() -> Result<(), Error> {
                 message.operations_for_block().hash().to_base58_check()
             );
 
-            match message.operation_hashes_path() {
-                Path::Right(path) => {
+            let Path(path_items) = message.operation_hashes_path();
+            assert_eq!(path_items.len(), 2);
+            match path_items[0] {
+                PathItem::Right(ref path) => {
                     assert_eq!(
                         "LLobFmsoFEGPP3q9ZxpE84rH1vPC1uKqEV8L1x8zUjGwanEYuHBVB",
                         HashType::OperationListListHash
                             .hash_to_b58check(path.left())
                             .unwrap()
                     );
-                    match path.path() {
-                        Path::Right(path) => {
-                            assert_eq!(
-                                "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc",
-                                HashType::OperationListListHash
-                                    .hash_to_b58check(path.left())
-                                    .unwrap()
-                            );
-                            match path.path() {
-                                Path::Op => Ok(()),
-                                _ => panic!("Unexpected path: {:?}. Was expecting Path::Op.", path),
-                            }
-                        }
-                        _ => panic!("Unexpected path: {:?}. Was expecting Path::Right.", path),
-                    }
                 }
                 _ => panic!(
-                    "Unexpected path: {:?}. Was expecting Path::Right.",
+                    "Unexpected path: {:?}. Was expecting Path::Left.",
                     message.operation_hashes_path()
                 ),
             }
+            match path_items[1] {
+                PathItem::Right(ref path) => {
+                    assert_eq!(
+                        "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc",
+                        HashType::OperationListListHash
+                            .hash_to_b58check(path.left())
+                            .unwrap()
+                    );
+                }
+                _ => panic!(
+                    "Unexpected path: {:?}. Was expecting Path::Left.",
+                    message.operation_hashes_path()
+                ),
+            }
+            Ok(())
         }
         _ => panic!("Unsupported encoding: {:?}", message),
     }
@@ -96,35 +101,37 @@ fn can_deserialize_operations_for_blocks_left() -> Result<(), Error> {
                 "Was expecting 5 operations but found {}",
                 message.operations().len()
             );
-            match message.operation_hashes_path() {
-                Path::Left(path) => {
+            let Path(path_items) = message.operation_hashes_path();
+            assert_eq!(path_items.len(), 2);
+            match path_items[0] {
+                PathItem::Left(ref path) => {
                     assert_eq!(
                         "LLoZQD2o1hNgoUhg6ha9dCVyRUY25GX1KN2TttXW2PZsyS8itbfpK",
                         HashType::OperationListListHash
                             .hash_to_b58check(path.right())
                             .unwrap()
                     );
-                    match path.path() {
-                        Path::Left(path) => {
-                            assert_eq!(
-                                "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc",
-                                HashType::OperationListListHash
-                                    .hash_to_b58check(path.right())
-                                    .unwrap()
-                            );
-                            match path.path() {
-                                Path::Op => Ok(()),
-                                _ => panic!("Unexpected path: {:?}. Was expecting Path::Op.", path),
-                            }
-                        }
-                        _ => panic!("Unexpected path: {:?}. Was expecting Path::Right.", path),
-                    }
                 }
                 _ => panic!(
-                    "Unexpected path: {:?}. Was expecting Path::Right.",
+                    "Unexpected path: {:?}. Was expecting Path::Left.",
                     message.operation_hashes_path()
                 ),
             }
+            match path_items[1] {
+                PathItem::Left(ref path) => {
+                    assert_eq!(
+                        "LLoaGLRPRx3Zf8kB4ACtgku8F4feeBiskeb41J1ciwfcXB3KzHKXc",
+                        HashType::OperationListListHash
+                            .hash_to_b58check(path.right())
+                            .unwrap()
+                    );
+                }
+                _ => panic!(
+                    "Unexpected path: {:?}. Was expecting Path::Left.",
+                    message.operation_hashes_path()
+                ),
+            }
+            Ok(())
         }
         _ => panic!("Unsupported encoding: {:?}", message),
     }
@@ -185,18 +192,13 @@ fn create_operations_for_blocks_encoded(depth: usize) -> Vec<u8> {
 }
 
 fn create_operations_for_blocks(depth: usize) -> PeerMessageResponse {
-    let mut path = Path::Op;
-    for i in 0..depth {
-        path = Path::Left(Box::new(PathLeft::new(
-            path,
-            get_hash((depth - i - 1) as u64, 32),
-            Default::default(),
-        )));
-    }
-
+    let path = (0..depth)
+        .map(|i| get_hash(i as u64, 32))
+        .map(|h| PathItem::Left(PathLeft::new(h, Default::default())))
+        .collect();
     let message = PeerMessage::OperationsForBlocks(OperationsForBlocksMessage::new(
         OperationsForBlock::new(get_hash(0xffffffff_u64, 32).try_into().unwrap(), 0x01),
-        path,
+        Path(path),
         Vec::new(),
     ));
 
@@ -205,17 +207,16 @@ fn create_operations_for_blocks(depth: usize) -> PeerMessageResponse {
 
 #[test]
 fn can_deserialize_operations_for_blocks_left_deep() -> Result<(), Error> {
-    let depth = PATH_MAX_DEPTH;
+    let depth = MAX_PASS_MERKLE_DEPTH.expect("Bounded encoding expected");
     let message_bytes = create_operations_for_blocks_encoded(depth as usize);
     let messages = PeerMessageResponse::from_bytes(message_bytes)?;
     assert_eq!(1, messages.messages().len());
 
     let message = messages.messages().get(0).unwrap();
     if let PeerMessage::OperationsForBlocks(message) = message {
-        let mut path = message.operation_hashes_path();
-        for _ in 0..depth {
-            if let Path::Left(b) = path {
-                path = b.path();
+        let Path(path) = message.operation_hashes_path();
+        for item in path {
+            if let PathItem::Left(_) = item {
             } else {
                 panic!("Unexpected path kind");
             }
@@ -228,16 +229,8 @@ fn can_deserialize_operations_for_blocks_left_deep() -> Result<(), Error> {
 
 #[test]
 fn can_deserialize_operations_for_blocks_left_too_deep() -> Result<(), Error> {
-    let message_bytes = create_operations_for_blocks_encoded(PATH_MAX_DEPTH as usize + 1);
-    let result = PeerMessageResponse::from_bytes(message_bytes);
-    assert!(result.is_err());
-    Ok(())
-}
-
-#[test]
-fn can_deserialize_operations_for_blocks_left_depth_overflow() -> Result<(), Error> {
     let message_bytes = create_operations_for_blocks_encoded(
-        tezos_encoding::types::RecursiveDataSize::max_value() as usize + 1,
+        MAX_PASS_MERKLE_DEPTH.expect("Bounded encoding expected") as usize + 1,
     );
     let result = PeerMessageResponse::from_bytes(message_bytes);
     assert!(result.is_err());
@@ -246,7 +239,7 @@ fn can_deserialize_operations_for_blocks_left_depth_overflow() -> Result<(), Err
 
 #[test]
 fn can_serialize_operations_for_blocks_left_deep() -> Result<(), Error> {
-    let depth = PATH_MAX_DEPTH as usize;
+    let depth = MAX_PASS_MERKLE_DEPTH.expect("Bounded encoding expected");
     let message = create_operations_for_blocks(depth);
     let encoded = PeerMessageResponse::from(message).as_bytes()?;
     let expected = create_operations_for_blocks_encoded(depth);
@@ -256,10 +249,9 @@ fn can_serialize_operations_for_blocks_left_deep() -> Result<(), Error> {
 }
 
 #[test]
-#[ignore]
-// Ignored until JSON serialization is implemented for operations for blocks
+#[ignore = "JSON serialization is not implemented for operations for blocks"]
 fn can_serialize_to_json_operations_for_blocks_left_deep() -> Result<(), Error> {
-    let depth = PATH_MAX_DEPTH as usize;
+    let depth = MAX_PASS_MERKLE_DEPTH.expect("Bounded encoding expected");
     let message = create_operations_for_blocks(depth);
     let _encoded = PeerMessageResponse::from(message).as_json()?;
 
@@ -268,23 +260,8 @@ fn can_serialize_to_json_operations_for_blocks_left_deep() -> Result<(), Error> 
 
 #[test]
 fn can_serialize_operations_for_blocks_left_too_deep() -> Result<(), Error> {
-    let message = create_operations_for_blocks(PATH_MAX_DEPTH as usize + 1);
-    let result = PeerMessageResponse::from(message).as_bytes();
-    assert!(result.is_err());
-
-    Ok(())
-}
-
-#[test]
-#[ignore]
-// this test should be run with caution since it allocates a linked list
-// containing 65536 elements and basing on stack size setting it might fail
-// deallocating that structure
-// TODO: TE-354
-fn can_serialize_operations_for_blocks_left_depth_overflow() -> Result<(), Error> {
-    let message = create_operations_for_blocks(
-        tezos_encoding::types::RecursiveDataSize::max_value() as usize + 1,
-    );
+    let message =
+        create_operations_for_blocks(MAX_PASS_MERKLE_DEPTH.expect("Bounded encoding expected") + 1);
     let result = PeerMessageResponse::from(message).as_bytes();
     assert!(result.is_err());
 


### PR DESCRIPTION
The idea is to get rid of recurstion in `Path` definition so `serde` derived impls are not recursive.

Still `compute_path` operation in OCaml generates the old recursive representation, so now `FfiPath` is defined pretty much like `Path` previously. Note that `FfiPath` conversion from OCaml is still recursive.

The main change is in `tezos/messages/src/p2p/encoding/operations_for_blocks.rs`. `Path` is used to be recursive, being either a `PathLeft` with right node hash and further path, `PathRight` left node hash and further path, or `Op`, denoting that the current node is the operation the path denotes. Now `PathLeft` and `PathRight` do not reference further path, they are just steps in a tree (see the `PathItem` holding one of them), and the `Path` now is the vector of these steps `PathItems`. Now derived serde implementations are used as no recursion is involved, and custom codec is modified to handle new data structure.

Another important thing is in OCaml FFI, that is involved to compute actual paths for operations. Now the old representation is moved there (`tezos/api/src/ocaml_conv/mod.rs`, `tezos/api/src/ocaml_conv/from_ocaml.rs`) and the new data structure is built from it in the `tezos/interop/src/ffi.rs`.

The rest is mostly tests update.