### PR TITLE
Add /dev/version RPC

### DIFF
--- a/rpc/src/server/dev_handler.rs
+++ b/rpc/src/server/dev_handler.rs
@@ -183,3 +183,19 @@ pub async fn context_stats(
         env.log(),
     )
 }
+
+/// Get the version string
+pub async fn dev_version(
+    _: Request<Body>,
+    _: Params,
+    _: Query,
+    env: RpcServiceEnvironment,
+) -> ServiceResult {
+    match dev_services::get_dev_version() {
+        Ok(resp) => make_json_response(&resp),
+        Err(e) => {
+            warn!(env.log(), "GetStatsMemory: {}", e);
+            empty()
+        }
+    }
+}

--- a/rpc/src/server/router.rs
+++ b/rpc/src/server/router.rs
@@ -225,6 +225,11 @@ pub(crate) fn create_routes(is_sandbox: bool) -> PathTree<MethodHandler> {
     );
     routes.handle(
         hash_set![Method::GET],
+        "/dev/version",
+        dev_handler::dev_version,
+    );
+    routes.handle(
+        hash_set![Method::GET],
         "/stats/memory",
         dev_handler::dev_stats_memory,
     );

--- a/rpc/src/services/dev_services.rs
+++ b/rpc/src/services/dev_services.rs
@@ -142,3 +142,9 @@ pub(crate) fn get_cycle_length_for_block(
         Ok(4096)
     }
 }
+
+pub(crate) fn get_dev_version() -> Result<String, failure::Error> {
+    let version_env: &'static str = env!("CARGO_PKG_VERSION");
+
+    Ok(format!("v{}", version_env.to_string()))
+}


### PR DESCRIPTION
This simple RPC returns the actual version of the node. 

**Note:** We already have `/version`, but that one does not include the `patch` number, only `major` and `minor`. If we include the patch number in that RPC, the node becomes incompatible with the tezos-client.  To be able to display the correct version on the FE and keep the compatibility with the tezos ocaml node, this was necessary. 