### PR TITLE
enable sanitization for tezos messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,18 +45,13 @@ jobs:
         run: brew install hidapi
         if: runner.os == 'macOS'
       - name: cargo check
+        if: matrix.sanitizer == 'none'
         uses: actions-rs/cargo@v1
         with:
           command: check
       - name: cargo test
-        if: matrix.sanitizer == 'none'
+        if: matrix.os != 'macos' && matrix.sanitizer != "address"
         uses: actions-rs/cargo@v1
         with:
           command: test
-      - name: cargo test
-        if: matrix.sanitizer == 'address' && matrix.os == 'ubuntu-latest'
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all --exclude tezos_messages
 


### PR DESCRIPTION
- New version for develop
- - run 'cargo check' once per OS - run 'cargo test' for every combination except macos with address sanitizer
