### PR TITLE
Remove release assertions [TE-378]

### DIFF
--- a/storage/src/persistent/codec.rs
+++ b/storage/src/persistent/codec.rs
@@ -16,6 +16,8 @@ pub enum SchemaError {
     EncodeError,
     #[fail(display = "Failed to decode value")]
     DecodeError,
+    #[fail(display = "Failed to decode value: {}", 0)]
+    DecodeValidationError(String),
 }
 
 impl From<crypto::hash::FromBytesError> for SchemaError {


### PR DESCRIPTION
- Replaced `assert_* with `debug_assert_*`
- Invalid encoded data is reported as Err
- Merge operator returns `None` in case of invalid data