### PR TITLE
Use debug_assert in TagMap::new [TE-254]

### DIFF
--- a/tezos/encoding/src/encoding.rs
+++ b/tezos/encoding/src/encoding.rs
@@ -83,7 +83,7 @@ impl TagMap {
             let tag_id = tag.get_id();
             let variant = tag.get_variant().to_string();
             let prev_item = id_to_tag.insert(tag_id, tag);
-            assert!(
+            debug_assert!(
                 prev_item.is_none(),
                 "Tag id: 0x{:X} is already present in TagMap",
                 tag_id


### PR DESCRIPTION
The function is used in `static` context where using `Result` is
problematic. This way duplicate tags will be reported in testing, and no
panic happens in release.