### PR TITLE
Add context information to reader/writer [TE-436]

### DIFF
--- a/tezos/encoding/src/binary_reader.rs
+++ b/tezos/encoding/src/binary_reader.rs
@@ -3,6 +3,9 @@
 
 //! Tezos binary data reader.
 
+use failure::ResultExt;
+use std::fmt::{self, Display};
+
 use bit_vec::BitVec;
 use bytes::Buf;
 use failure::Fail;
@@ -13,9 +16,32 @@ use crate::de;
 use crate::encoding::{Encoding, Field, SchemaType};
 use crate::types::{self, Value};
 
+use super::error_context::EncodingError;
+
 /// Error produced by a [BinaryReader].
-#[derive(Debug, Fail)]
-pub enum BinaryReaderError {
+pub type BinaryReaderError = EncodingError<BinaryReaderErrorKind>;
+
+/// Actual size of encoded data
+#[derive(Debug, Clone, Copy)]
+pub enum ActualSize {
+    /// Exact size
+    Exact(usize),
+    /// Unknown size exceeding the limit
+    GreaterThan(usize),
+}
+
+impl Display for ActualSize {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            ActualSize::Exact(size) => write!(f, "{}", size),
+            ActualSize::GreaterThan(size) => write!(f, "greater than {}", size),
+        }
+    }
+}
+
+/// Kind of error for [BinaryReaderError]
+#[derive(Debug, Fail, Clone)]
+pub enum BinaryReaderErrorKind {
     /// More bytes were expected than there were available in input buffer.
     #[fail(display = "Input underflow, missing {} bytes", bytes)]
     Underflow { bytes: usize },
@@ -23,7 +49,7 @@ pub enum BinaryReaderError {
     #[fail(display = "Input overflow, excess of {} bytes", bytes)]
     Overflow { bytes: usize },
     /// Generic deserialization error.
-    #[fail(display = "Message de-serialization error: {:?}", error)]
+    #[fail(display = "Deserializer error: {}", error)]
     DeserializationError { error: crate::de::Error },
     /// No tag with the corresponding id was found. This might not be an error of the binary data but
     /// may simply mean that we have not yet defined tag in encoding.
@@ -31,10 +57,14 @@ pub enum BinaryReaderError {
     UnsupportedTag { tag: u16 },
     /// Encoding boundary constraint violation
     #[fail(
-        display = "Encoded data {} exceeded its size boundary: {}",
-        name, boundary
+        display = "Encoded data {} exceeded its size boundary: {}, actual: {}",
+        name, boundary, actual
     )]
-    EncodingBoundaryExceeded { name: String, boundary: usize },
+    EncodingBoundaryExceeded {
+        name: String,
+        boundary: usize,
+        actual: ActualSize,
+    },
     /// Arithmetic overflow
     #[fail(display = "Arithmetic overflow while encoding {:?}", encoding)]
     ArithmeticOverflow { encoding: &'static str },
@@ -42,23 +72,25 @@ pub enum BinaryReaderError {
 
 impl From<crate::de::Error> for BinaryReaderError {
     fn from(error: crate::de::Error) -> Self {
-        BinaryReaderError::DeserializationError { error }
+        BinaryReaderErrorKind::DeserializationError { error }.into()
     }
 }
 
 impl From<std::string::FromUtf8Error> for BinaryReaderError {
     fn from(from: std::string::FromUtf8Error) -> Self {
-        BinaryReaderError::DeserializationError {
+        BinaryReaderErrorKind::DeserializationError {
             error: de::Error::custom(format!("Error decoding UTF-8 string. Reason: {:?}", from)),
         }
+        .into()
     }
 }
 
 impl From<crate::bit_utils::BitsError> for BinaryReaderError {
     fn from(source: crate::bit_utils::BitsError) -> Self {
-        Self::DeserializationError {
+        BinaryReaderErrorKind::DeserializationError {
             error: crate::de::Error::custom(format!("Bits operation error: {:?}", source)),
         }
+        .into()
     }
 }
 
@@ -70,18 +102,18 @@ macro_rules! safe {
         if $buf.remaining() >= size_of::<$sz>() {
             $buf.$foo()
         } else {
-            return Result::Err(BinaryReaderError::Underflow {
+            return Result::Err(BinaryReaderErrorKind::Underflow {
                 bytes: (size_of::<$sz>() - $buf.remaining()),
-            });
+            })?;
         }
     }};
     ($buf:ident, $sz:expr, $exp:expr) => {{
         if $buf.remaining() >= $sz {
             $exp
         } else {
-            return Result::Err(BinaryReaderError::Underflow {
+            return Result::Err(BinaryReaderErrorKind::Underflow {
                 bytes: ($sz - $buf.remaining()),
-            });
+            })?;
         }
     }};
 }
@@ -144,9 +176,9 @@ impl BinaryReader {
         if buf.remaining() == 0 {
             Ok(result)
         } else {
-            Err(BinaryReaderError::Overflow {
+            Err(BinaryReaderErrorKind::Overflow {
                 bytes: buf.remaining(),
-            })
+            })?
         }
     }
 
@@ -159,7 +191,11 @@ impl BinaryReader {
         for field in schema {
             let name = field.get_name();
             let encoding = field.get_encoding();
-            values.push((name.clone(), self.decode_value(buf, encoding)?))
+            values.push((
+                name.clone(),
+                self.decode_value(buf, encoding)
+                    .with_context(|e| e.field(field.get_name()))?,
+            ))
         }
         Ok(Value::Record(values))
     }
@@ -199,8 +235,7 @@ impl BinaryReader {
                     _ => Err(de::Error::custom(format!(
                         "Vas expecting 0xFF or 0x00 but instead got {:X}",
                         b
-                    ))
-                    .into()),
+                    )))?,
                 }
             }
             Encoding::String => {
@@ -213,10 +248,11 @@ impl BinaryReader {
             Encoding::BoundedString(bytes_max) => {
                 let bytes_sz = safe!(buf, get_u32, u32) as usize;
                 if bytes_sz > *bytes_max {
-                    Err(BinaryReaderError::EncodingBoundaryExceeded {
+                    Err(BinaryReaderErrorKind::EncodingBoundaryExceeded {
                         name: "Encoding::BoundedString".to_string(),
                         boundary: *bytes_max,
-                    })
+                        actual: ActualSize::Exact(bytes_sz),
+                    })?
                 } else {
                     let mut str_buf = vec![0u8; bytes_sz].into_boxed_slice();
                     safe!(buf, bytes_sz, buf.copy_to_slice(&mut str_buf));
@@ -233,10 +269,11 @@ impl BinaryReader {
             Encoding::BoundedDynamic(max, dynamic_encoding) => {
                 let bytes_sz = safe!(buf, get_u32, u32) as usize;
                 if bytes_sz > *max {
-                    Err(BinaryReaderError::EncodingBoundaryExceeded {
+                    Err(BinaryReaderErrorKind::EncodingBoundaryExceeded {
                         name: "Encoding::BoundedDynamic".to_string(),
                         boundary: *max,
-                    })
+                        actual: ActualSize::Exact(bytes_sz),
+                    })?
                 } else {
                     let mut buf_slice = safe!(buf, bytes_sz, buf.take(bytes_sz));
                     self.decode_value(&mut buf_slice, dynamic_encoding)
@@ -251,12 +288,16 @@ impl BinaryReader {
                 let mut buf_slice = safe!(buf, upper, buf.take(upper));
                 let res = self.decode_value(&mut buf_slice, inner_encoding);
                 match res {
-                    Err(BinaryReaderError::Underflow { bytes: _ }) => {
-                        Err(BinaryReaderError::EncodingBoundaryExceeded {
-                            name: "Encoding::Bounded".to_string(),
-                            boundary: *max,
-                        })
-                    }
+                    Err(e) => match e.kind() {
+                        BinaryReaderErrorKind::Underflow { bytes } if upper == *max => {
+                            Err(BinaryReaderErrorKind::EncodingBoundaryExceeded {
+                                name: "Encoding::Bounded".to_string(),
+                                boundary: *max,
+                                actual: ActualSize::Exact(bytes),
+                            })?
+                        }
+                        _ => Err(e),
+                    },
                     r => r,
                 }
             }
@@ -283,7 +324,7 @@ impl BinaryReader {
                             Box::new(tag_value),
                         ))
                     }
-                    None => Err(BinaryReaderError::UnsupportedTag { tag: tag_id }),
+                    None => Err(BinaryReaderErrorKind::UnsupportedTag { tag: tag_id })?,
                 }
             }
             Encoding::List(encoding_inner) => {
@@ -293,7 +334,10 @@ impl BinaryReader {
 
                 let mut values = vec![];
                 while buf_slice.remaining() > 0 {
-                    values.push(self.decode_value(&mut buf_slice, encoding_inner)?);
+                    values.push(
+                        self.decode_value(&mut buf_slice, encoding_inner)
+                            .with_context(|e| e.element_of())?,
+                    );
                 }
 
                 Ok(Value::List(values))
@@ -306,12 +350,16 @@ impl BinaryReader {
                 let mut values = vec![];
                 while buf_slice.remaining() > 0 {
                     if values.len() >= *max {
-                        return Err(BinaryReaderError::EncodingBoundaryExceeded {
+                        return Err(BinaryReaderErrorKind::EncodingBoundaryExceeded {
                             name: "Encoding::List".to_string(),
                             boundary: *max,
-                        });
+                            actual: ActualSize::GreaterThan(values.len()),
+                        })?;
                     }
-                    values.push(self.decode_value(&mut buf_slice, encoding_inner)?);
+                    values.push(
+                        self.decode_value(&mut buf_slice, encoding_inner)
+                            .with_context(|e| e.element_of())?,
+                    );
                 }
 
                 Ok(Value::List(values))
@@ -327,8 +375,7 @@ impl BinaryReader {
                     _ => Err(de::Error::custom(format!(
                         "Unexpected option value {:X}",
                         is_present_byte
-                    ))
-                    .into()),
+                    )))?,
                 }
             }
             Encoding::OptionalField(inner_encoding) => {
@@ -342,8 +389,7 @@ impl BinaryReader {
                     _ => Err(de::Error::custom(format!(
                         "Unexpected option value {:X}",
                         is_present_byte
-                    ))
-                    .into()),
+                    )))?,
                 }
             }
             Encoding::Obj(schema_inner) => Ok(self.decode_record(buf, schema_inner)?),
@@ -456,9 +502,9 @@ impl BinaryReader {
                 self.decode_value(buf, &inner_encoding)
             }
             Encoding::Custom(codec) => codec.decode(buf, encoding),
-            Encoding::Uint32 | Encoding::RangedInt | Encoding::RangedFloat => {
-                Err(de::Error::custom(format!("Unsupported encoding {:?}", encoding)).into())
-            }
+            Encoding::Uint32 | Encoding::RangedInt | Encoding::RangedFloat => Err(
+                de::Error::custom(format!("Unsupported encoding {:?}", encoding)),
+            )?,
         }
     }
 }
@@ -718,5 +764,72 @@ mod tests {
 
         let record_deserialized: Option<Record> = de::from_value(&value).unwrap();
         assert_eq!(record, record_deserialized);
+    }
+
+    #[test]
+    fn deserialize_bounds_error_location_string() {
+        let schema = Encoding::Obj(vec![Field::new("xxx", Encoding::BoundedString(1))]);
+        let data = hex::decode("000000020000").unwrap();
+        let err = BinaryReader::new()
+            .read(data, &schema)
+            .expect_err("Error is expected");
+        let kind = err.kind();
+        assert!(matches!(
+            kind,
+            BinaryReaderErrorKind::EncodingBoundaryExceeded {
+                name: _,
+                boundary: 1,
+                actual: ActualSize::Exact(2)
+            }
+        ));
+        let location = err.location();
+        assert!(location.contains("field `xxx`"));
+    }
+
+    #[test]
+    fn deserialize_bounds_error_location_list() {
+        let schema = Encoding::Obj(vec![Field::new(
+            "xxx",
+            Encoding::bounded_list(1, Encoding::Uint8),
+        )]);
+        let data = hex::decode("0000").unwrap();
+        let err = BinaryReader::new()
+            .read(data, &schema)
+            .expect_err("Error is expected");
+        let kind = err.kind();
+        assert!(matches!(
+            kind,
+            BinaryReaderErrorKind::EncodingBoundaryExceeded {
+                name: _,
+                boundary: 1,
+                actual: ActualSize::GreaterThan(1)
+            }
+        ));
+        let location = err.location();
+        assert!(location.contains("field `xxx`"));
+    }
+
+    #[test]
+    fn deserialize_bounds_error_location_element_of() {
+        let schema = Encoding::Obj(vec![Field::new(
+            "xxx",
+            Encoding::list(Encoding::BoundedString(1)),
+        )]);
+        let data = hex::decode("000000020000").unwrap();
+        let err = BinaryReader::new()
+            .read(data, &schema)
+            .expect_err("Error is expected");
+        let kind = err.kind();
+        assert!(matches!(
+            kind,
+            BinaryReaderErrorKind::EncodingBoundaryExceeded {
+                name: _,
+                boundary: 1,
+                actual: ActualSize::Exact(2)
+            }
+        ));
+        let location = err.location();
+        assert!(location.contains("field `xxx`"));
+        assert!(location.contains("list element"));
     }
 }

--- a/tezos/encoding/src/error_context.rs
+++ b/tezos/encoding/src/error_context.rs
@@ -1,0 +1,107 @@
+// Copyright (c) SimpleStaking and Tezedge Contributors
+// SPDX-License-Identifier: MIT
+
+use failure::Fail;
+use failure::{Backtrace, Context};
+use std::fmt::{self, Display};
+
+/// Error produced by a [BinaryReader].
+#[derive(Debug)]
+pub struct EncodingError<T: Display + Send + Sync + 'static> {
+    inner: Context<ErrorInfo<T>>,
+}
+
+impl<T: Display + Send + Sync + std::fmt::Debug + 'static> Fail for EncodingError<T> {
+    fn cause(&self) -> Option<&dyn Fail> {
+        self.inner.cause()
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.inner.backtrace()
+    }
+}
+
+impl<T: Display + Send + Sync + 'static> Display for EncodingError<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.inner, f)
+    }
+}
+
+impl<T: Display + Send + Sync + Clone + 'static> EncodingError<T> {
+    pub fn kind(&self) -> T {
+        self.inner.get_context().0.clone()
+    }
+
+    pub fn location(&self) -> &String {
+        &self.inner.get_context().1
+    }
+
+    pub(crate) fn field(&self, name: &String) -> ErrorInfo<T> {
+        self.inner.get_context().field(name)
+    }
+
+    pub(crate) fn element_of(&self) -> ErrorInfo<T> {
+        self.inner.get_context().element_of()
+    }
+}
+
+impl<T: Display + Send + Sync + 'static> From<T> for EncodingError<T> {
+    fn from(kind: T) -> Self {
+        EncodingError {
+            inner: Context::new(kind.into()),
+        }
+    }
+}
+
+impl<T: Display + Send + Sync + 'static> From<ErrorInfo<T>> for EncodingError<T> {
+    fn from(info: ErrorInfo<T>) -> Self {
+        Self {
+            inner: Context::new(info),
+        }
+    }
+}
+
+impl<T: Display + Send + Sync + 'static> From<Context<ErrorInfo<T>>> for EncodingError<T> {
+    fn from(context: Context<ErrorInfo<T>>) -> Self {
+        Self { inner: context }
+    }
+}
+
+/// Error kind with a string describing the error context
+pub(crate) struct ErrorInfo<T: Display + Send + Sync + 'static>(T, String);
+
+impl<T: Display + Send + Sync + Clone + 'static> ErrorInfo<T> {
+    pub fn field(&self, name: &String) -> Self {
+        let msg = if self.1.is_empty() {
+            format!("field `{}`", name)
+        } else {
+            format!("{} @ field `{}`", self.1, name)
+        };
+        ErrorInfo(self.0.clone(), msg)
+    }
+
+    pub fn element_of(&self) -> Self {
+        let msg = if self.1.is_empty() {
+            format!("list element")
+        } else {
+            format!("{} @ list element", self.1)
+        };
+        ErrorInfo(self.0.clone(), msg)
+    }
+}
+
+impl<T: Display + Send + Sync + 'static> Display for ErrorInfo<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if self.1.is_empty() {
+            write!(f, "{} @ unknown location", self.0)
+        } else {
+            write!(f, "{} @ {}", self.0, self.1)
+        }
+    }
+}
+
+impl<T: Display + Send + Sync + 'static> From<T> for ErrorInfo<T> {
+    fn from(kind: T) -> Self {
+        Self(kind, "".to_string())
+    }
+}

--- a/tezos/encoding/src/lib.rs
+++ b/tezos/encoding/src/lib.rs
@@ -11,5 +11,6 @@ pub mod binary_reader;
 pub mod binary_writer;
 pub mod de;
 pub mod encoding;
+pub mod error_context;
 pub mod json_writer;
 pub mod ser;

--- a/tezos/encoding/src/ser.rs
+++ b/tezos/encoding/src/ser.rs
@@ -51,7 +51,7 @@ impl ser::Error for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_fmt(format_args!("{}", self))
+        formatter.write_fmt(format_args!("{}", self.message))
     }
 }
 

--- a/tezos/messages/src/p2p/encoding/operations_for_blocks.rs
+++ b/tezos/messages/src/p2p/encoding/operations_for_blocks.rs
@@ -10,7 +10,7 @@ use getset::{CopyGetters, Getters};
 use serde::{Deserialize, Serialize};
 
 use crypto::hash::{BlockHash, Hash, HashType};
-use tezos_encoding::binary_reader::BinaryReaderError;
+use tezos_encoding::binary_reader::{ActualSize, BinaryReaderError, BinaryReaderErrorKind};
 use tezos_encoding::encoding::{CustomCodec, Encoding, Field, HasEncoding};
 use tezos_encoding::ser::Error;
 use tezos_encoding::types::Value;
@@ -506,16 +506,17 @@ impl CustomCodec for PathCodec {
                     return Ok(Value::List(result));
                 }
                 t => {
-                    return Err(BinaryReaderError::UnsupportedTag { tag: t as u16 });
+                    return Err(BinaryReaderErrorKind::UnsupportedTag { tag: t as u16 })?;
                 }
             }
             match MAX_PASS_MERKLE_DEPTH {
                 Some(max) => {
                     if nodes.len() > max {
-                        return Err(BinaryReaderError::EncodingBoundaryExceeded {
+                        return Err(BinaryReaderErrorKind::EncodingBoundaryExceeded {
                             name: "Path".to_string(),
                             boundary: max,
-                        });
+                            actual: ActualSize::Exact(nodes.len()),
+                        })?;
                     }
                 }
                 _ => (),

--- a/tezos/messages/tests/encoding_advertise.rs
+++ b/tezos/messages/tests/encoding_advertise.rs
@@ -5,7 +5,7 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 
 use failure::Error;
 
-use tezos_encoding::binary_reader::BinaryReaderError;
+use tezos_encoding::binary_reader::{ActualSize, BinaryReaderErrorKind};
 use tezos_messages::p2p::encoding::prelude::*;
 use tezos_messages::p2p::{
     binary_message::BinaryMessage, encoding::limits::ADVERTISE_ID_LIST_MAX_LENGTH,
@@ -81,13 +81,14 @@ fn can_deserialize_advertize_max() -> Result<(), Error> {
 #[test]
 fn can_t_deserialize_advertize_max_plus() -> Result<(), Error> {
     let encoded = hex::decode(test_data::ADVERTISE_ENCODED_OVER_MAX)?;
-    let res = AdvertiseMessage::from_bytes(encoded);
+    let err = AdvertiseMessage::from_bytes(encoded).expect_err("Error is expected");
     assert!(matches!(
-        res,
-        Err(BinaryReaderError::EncodingBoundaryExceeded {
+        err.kind(),
+        BinaryReaderErrorKind::EncodingBoundaryExceeded {
             name: _,
-            boundary: ADVERTISE_ID_LIST_MAX_LENGTH
-        })
+            boundary: ADVERTISE_ID_LIST_MAX_LENGTH,
+            actual: ActualSize::GreaterThan(ADVERTISE_ID_LIST_MAX_LENGTH)
+        }
     ));
     Ok(())
 }

--- a/tezos/messages/tests/encoding_swap.rs
+++ b/tezos/messages/tests/encoding_swap.rs
@@ -1,7 +1,7 @@
 use crypto::hash::HashType;
 use failure::Error;
 use std::{convert::TryInto, iter};
-use tezos_encoding::binary_reader::BinaryReaderError;
+use tezos_encoding::binary_reader::{ActualSize, BinaryReaderErrorKind};
 use tezos_messages::p2p::binary_message::BinaryMessage;
 use tezos_messages::p2p::encoding::limits::*;
 use tezos_messages::p2p::encoding::swap::*;
@@ -46,13 +46,14 @@ fn can_deserialize_swap_max() -> Result<(), Error> {
 #[test]
 fn can_t_deserialize_swap_point_max_plus() -> Result<(), Error> {
     let encoded = hex::decode(data::SWAP_MESSAGE_POINT_OVER_MAX)?;
-    let res = SwapMessage::from_bytes(encoded);
+    let err = SwapMessage::from_bytes(encoded).expect_err("Error is expected");
     assert!(matches!(
-        res,
-        Err(BinaryReaderError::EncodingBoundaryExceeded {
+        err.kind(),
+        BinaryReaderErrorKind::EncodingBoundaryExceeded {
             name: _,
-            boundary: P2P_POINT_MAX_LENGTH
-        })
+            boundary: P2P_POINT_MAX_LENGTH,
+            actual: ActualSize::Exact(actual),
+        } if actual == P2P_POINT_MAX_LENGTH + 1
     ));
     Ok(())
 }
@@ -60,8 +61,11 @@ fn can_t_deserialize_swap_point_max_plus() -> Result<(), Error> {
 #[test]
 fn can_t_deserialize_swap_peer_id_max_plus() -> Result<(), Error> {
     let encoded = hex::decode(data::SWAP_MESSAGE_PEER_ID_OVER_MAX)?;
-    let res = SwapMessage::from_bytes(encoded);
-    assert!(matches!(res, Err(BinaryReaderError::Overflow { bytes: 1 })));
+    let err = SwapMessage::from_bytes(encoded).expect_err("Error is expected");
+    assert!(matches!(
+        err.kind(),
+        BinaryReaderErrorKind::Overflow { bytes: 1 }
+    ));
     Ok(())
 }
 


### PR DESCRIPTION
Now messages from both binary encoding and decoding are supplied with the context information, field/list element. I think that will be enough to locate problematic place in values/bytes. 