### PR TITLE
Safer handling of String encoding

### DIFF
--- a/tezos/api/src/environment.rs
+++ b/tezos/api/src/environment.rs
@@ -770,7 +770,7 @@ impl ZcashParams {
 
 #[cfg(test)]
 mod tests {
-    use tezos_messages::ts_to_rfc3339;
+    use tezos_messages::{p2p::encoding::limits::CHAIN_NAME_MAX_LENGTH, ts_to_rfc3339};
 
     use super::*;
 
@@ -823,6 +823,22 @@ mod tests {
                 .bootstrap_lookup_addresses
                 .iter()
                 .for_each(|addr| assert!(parse_bootstrap_addr_port(addr, 1111).is_ok()));
+        });
+    }
+
+    #[test]
+    fn test_network_version_length() {
+        TezosEnvironment::iter().for_each(|net| {
+            let tezos_env: &TezosEnvironmentConfiguration = TEZOS_ENV
+                .get(&net)
+                .unwrap_or_else(|| panic!("no tezos environment configured for: {:?}", &net));
+
+            assert!(
+                tezos_env.version.len() <= CHAIN_NAME_MAX_LENGTH,
+                "The chain version {} does not fit into the CHAIN_NAME_MAX_LENGTH value {}",
+                tezos_env.version.len(),
+                CHAIN_NAME_MAX_LENGTH
+            );
         });
     }
 }

--- a/tezos/messages/src/p2p/encoding/limits.rs
+++ b/tezos/messages/src/p2p/encoding/limits.rs
@@ -213,3 +213,10 @@ pub const GET_OPERATIONS_FOR_BLOCKS_MAX_LENGTH: usize = 10;
 ///  let operation_list_max_size = ref (Some (1024 * 1024)) (* FIXME: arbitrary *)
 /// ```
 pub const OPERATION_LIST_MAX_SIZE: usize = 1024 * 1024;
+
+/// Maximal lenght for Tezos chain name.
+///
+/// Currently the longest one is the `TEZOS_ALPHANET_CARTHAGE_2019-11-28T13:02:13Z`.
+/// It should be pretty safe to have the length greater than that.
+///
+pub const CHAIN_NAME_MAX_LENGTH: usize = 128;

--- a/tezos/messages/src/p2p/encoding/version.rs
+++ b/tezos/messages/src/p2p/encoding/version.rs
@@ -12,6 +12,8 @@ use tezos_encoding::has_encoding;
 use crate::cached_data;
 use crate::p2p::binary_message::cache::BinaryDataCache;
 
+use super::limits::CHAIN_NAME_MAX_LENGTH;
+
 /// Holds informations about chain compatibility, features compatibility...
 #[derive(Serialize, Deserialize, Getters, Clone)]
 pub struct NetworkVersion {
@@ -53,7 +55,7 @@ impl NetworkVersion {
 cached_data!(NetworkVersion, body);
 has_encoding!(NetworkVersion, NETWORK_VERSION_ENCODING, {
     Encoding::Obj(vec![
-        Field::new("chain_name", Encoding::String),
+        Field::new("chain_name", Encoding::BoundedString(CHAIN_NAME_MAX_LENGTH)),
         Field::new("distributed_db_version", Encoding::Uint16),
         Field::new("p2p_version", Encoding::Uint16),
     ])


### PR DESCRIPTION
- Vector is not preallocated when decoding strings
- Remaining size is checked when decoding strings
- `NetworkVersion.chain_name` is constrained