### PR TITLE
Use consistent max logging level

### DIFF
--- a/light_node/Cargo.toml
+++ b/light_node/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3"
 riker = "0.4"
 rlimit = "0.5"
 serde_json = "1.0"
-slog = { version = "2.7", features = ["max_level_trace"] }
+slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 slog-async = "2.6"
 slog-json = "2.3"
 slog-term = "2.6"

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -10,7 +10,7 @@ chrono = "0.4"
 libflate = "1"
 nix = "0.19"
 serde = { version = "1.0", features = ["derive"] }
-slog = "2.7"
+slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 slog-json = "2.3"
 
 [dev-dependencies]

--- a/monitoring/Cargo.toml
+++ b/monitoring/Cargo.toml
@@ -9,7 +9,7 @@ erased-serde = "0.3"
 riker = "0.4"
 serde = "1.0"
 serde_json = "1.0"
-slog = { version = "2.7", features = ["nested-values"] }
+slog = { version = "2.7", features = ["nested-values", "max_level_trace", "release_max_level_debug"] }
 slog_derive = "0.1.1"
 # local dependencies
 crypto = { path = "../crypto" }

--- a/networking/Cargo.toml
+++ b/networking/Cargo.toml
@@ -10,7 +10,7 @@ failure = "0.1"
 futures = "0.3"
 hex = "0.4"
 riker = "0.4"
-slog = "2.7"
+slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 tokio = { version = "1.2", features = ["time", "net", "io-util", "rt-multi-thread"] }
 # local dependencies
 crypto = { path = "../crypto" }

--- a/protocol_runner/Cargo.toml
+++ b/protocol_runner/Cargo.toml
@@ -9,7 +9,7 @@ clap = "2.33"
 ctrlc = "3.1.3"
 failure = "0.1"
 failure_derive = "0.1"
-slog = "2.7"
+slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 slog-async = "2.6"
 slog-term = "2.6"
 # local dependencies

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -17,7 +17,7 @@ path-tree = "0.1.9"
 riker = "0.4"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
-slog = { version = "2.7", features = ["nested-values"] }
+slog = { version = "2.7", features = ["nested-values", "max_level_trace", "release_max_level_debug"] }
 tokio = { version = "1.2", features = ["time"] }
 rayon = "1.5"
 # local dependencies

--- a/sandbox/Cargo.toml
+++ b/sandbox/Cargo.toml
@@ -13,7 +13,7 @@ nix = "0.19"
 rand = "0.7.3"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
-slog = { version = "2.7", features = ["nested-values"] }
+slog = { version = "2.7", features = ["nested-values", "max_level_trace", "release_max_level_debug"] }
 slog-async = "2.6"
 slog-term = "2.6"
 tokio = { version = "1.2", features = ["full"] }

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -19,7 +19,7 @@ page_size = "0.4.1"
 rand = "0.7.3"
 regex = "1.4"
 riker = "0.4"
-slog = "2.7"
+slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1.2", features = ["time"] }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -19,7 +19,7 @@ leb128 = "0.2"
 num_cpus = "1.13"
 rocksdb = {version = "0.15", features = ["snappy", "lz4", "zstd", "zlib"], default-features = false }
 serde = { version = "1.0", features = ["derive", "rc"] }
-slog = "2.7"
+slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 sled = "0.34.6"
 snap = "1.0.4"
 strum = "0.20"

--- a/tezos/api/Cargo.toml
+++ b/tezos/api/Cargo.toml
@@ -12,7 +12,7 @@ lazy_static = "1.4"
 ocaml-interop = { version = "0.7.2", features = ["without-ocamlopt"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-slog = "2.7"
+slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 strum = "0.20"
 strum_macros = "0.20"
 # local dependencies

--- a/tezos/wrapper/Cargo.toml
+++ b/tezos/wrapper/Cargo.toml
@@ -13,7 +13,7 @@ nix = "0.19"
 rand = "0.7.3"
 r2d2 = "0.8.9"
 serde = { version = "1.0", features = ["derive"] }
-slog = "2.7"
+slog = { version = "2.7", features = ["max_level_trace", "release_max_level_debug"] }
 strum_macros = "0.20"
 wait-timeout = "0.2"
 # local dependencies


### PR DESCRIPTION
Debug builds will have all logging levels enabled.
Release builds will have debug as a maximum possible level.